### PR TITLE
Fixed .all exception and remove tokens button for CPN

### DIFF
--- a/src/main/java/net/tapaal/gui/GuiFrameController.java
+++ b/src/main/java/net/tapaal/gui/GuiFrameController.java
@@ -239,7 +239,7 @@ public final class GuiFrameController implements GuiFrameControllerActions{
         buffer.append("TAPAAL GUI and Translations:\n");
             buffer.append("Mathias Andersen, Sine V. Birch, Jacob Hjort Bundgaard, Joakim Byg, Jakob Dyhr,\nLouise Foshammer, Malte Neve-Graesboell, ");
             buffer.append("Lasse Jacobsen, Morten Jacobsen,\nThomas S. Jacobsen, Jacob J. Jensen, Peter G. Jensen, ");
-            buffer.append("Mads Johannsen,\nKenneth Y. Joergensen, Mikael H. Moeller, Christoffer Moesgaard, Kristian Morsing Pedersen,\nThomas Pedersen, Lena Said, Niels N. Samuelsen, Jiri Srba, Mathias G. Soerensen,\nJakob H. Taankvist and Peter H. Taankvist\n");
+            buffer.append("Mads Johannsen,\nKenneth Y. Joergensen, Mikael H. Moeller, Christoffer Moesgaard, Kristian Morsing Pedersen,\nThomas Pedersen, Lena S. Ernstsen, Niels N. Samuelsen, Jiri Srba, Mathias G. Soerensen,\nJakob H. Taankvist and Peter H. Taankvist\n");
 
             buffer.append("Aalborg University 2008-2021\n\n");
 

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
@@ -82,7 +82,7 @@ public abstract class ColorComboboxPanel extends JPanel {
     private void setIndex(ColorExpression expr, int index){
         if(expr instanceof AllExpression){
             //.all is always last so we just select the last item
-            colorTypeComboBoxesArray[index].setSelectedIndex(colorTypeComboBoxesArray[index].getItemCount());
+            colorTypeComboBoxesArray[index].setSelectedIndex(colorTypeComboBoxesArray[index].getItemCount() - 1);
         } else if(expr instanceof VariableExpression){
             colorTypeComboBoxesArray[index].setSelectedItem(((VariableExpression)expr).getVariable());
         } else if(expr instanceof UserOperatorExpression){

--- a/src/main/java/pipe/gui/petrinet/editor/PlaceEditorPanel.java
+++ b/src/main/java/pipe/gui/petrinet/editor/PlaceEditorPanel.java
@@ -856,7 +856,7 @@ public class PlaceEditorPanel extends JPanel {
             }
 
         });
-        removeColoredTokenButton.setEnabled(false);
+        removeColoredTokenButton.setEnabled(tokenList.getSelectedIndex() > 0);
         gbc = new GridBagConstraints();
         gbc.gridx = 1;
         gbc.gridy = 0;


### PR DESCRIPTION
Fixes the out of bounds exception that is produced when adding a .all token to a place (bug https://bugs.launchpad.net/tapaal/+bug/1983365)

Fixes disabled remove button when only one token is in the list of tokens (bug https://bugs.launchpad.net/tapaal/+bug/1983367)

Also corrected my name in the contributions :)