### PR TITLE
unfold-empty-net-1983366

### DIFF
--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNUnfoldOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNUnfoldOptions.java
@@ -25,8 +25,6 @@ public class VerifyPNUnfoldOptions extends VerificationOptions {
         symmetricVars = useSymmetricVars;
     }
 
-
-
     @Override
     public boolean enabledOverApproximation() {
         return false;
@@ -79,10 +77,10 @@ public class VerifyPNUnfoldOptions extends VerificationOptions {
         if(!computeColorFixpoint){
             result.append(" --disable-cfp");
         }
-
         if(!symmetricVars){
             result.append(" --disable-symmetry-vars");
         }
+        result.append(" --col-reduction 0");
 
         return result.toString();
     }

--- a/src/main/java/net/tapaal/gui/petrinet/TabTransformer.java
+++ b/src/main/java/net/tapaal/gui/petrinet/TabTransformer.java
@@ -294,7 +294,6 @@ public class TabTransformer {
     }
 
     public static void unfoldTab(PetriNetTab oldTab, boolean partition, boolean computeColorFixpoint, boolean useSymmetricVars) {
-
         ModelChecker engine;
         if(oldTab.getLens().isTimed()){
             engine = new VerifyDTAPN(new FileFinder(), new MessengerImpl());
@@ -312,7 +311,7 @@ public class TabTransformer {
         UnfoldNet thread = new UnfoldNet(engine, new MessengerImpl(), oldTab.getGuiModels(), partition, computeColorFixpoint, useSymmetricVars);
         RunningVerificationDialog dialog = new RunningVerificationDialog(TAPAALGUI.getApp(), thread, "Unfolding");
         SmartDrawDialog.setupWorkerListener(thread);
-        thread.execute(oldTab.network(), oldTab.queries(), oldTab);
+        thread.execute(oldTab.network(), oldTab);
         dialog.setVisible(true);
     }
 


### PR DESCRIPTION
Added --col-reduction 0 (-R 0) to the argument string when unfolding by either pressing M or selecting unfold.
Uses the query EF true when unfolding even when there are queries in the net.

Solves https://bugs.launchpad.net/tapaal/+bug/1983366