### PR TITLE
Unfold query category 1960299

### DIFF
--- a/src/main/java/dk/aau/cs/approximation/ApproximationWorker.java
+++ b/src/main/java/dk/aau/cs/approximation/ApproximationWorker.java
@@ -63,7 +63,8 @@ public class ApproximationWorker {
 
 		result = modelChecker.verify(options, transformedModel, clonedQuery, guiModel, dataLayerQuery, lens);
 
-		if (result.error()) {
+		if (result == null) return null;
+        if (result.error()) {
 			options.setTraceOption(oldTraceOption);
 			return new VerificationResult<TAPNNetworkTrace>(result.errorMessage(), result.verificationTime());
 		}

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPN.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPN.java
@@ -309,7 +309,7 @@ public class VerifyDTAPN implements ModelChecker{
                                 newTab = new PetriNetTab(loadedModel.network(), loadedModel.templates(), loadedModel.queries(), new TAPNLens(lens.isTimed(), lens.isGame(), false));
 
                                 //The query being verified should be the only query
-                                for (net.tapaal.gui.petrinet.verification.TAPNQuery loadedQuery : UnfoldNet.getQueries(queriesOut, loadedModel.network())) {
+                                for (net.tapaal.gui.petrinet.verification.TAPNQuery loadedQuery : UnfoldNet.getQueries(queriesOut, loadedModel.network(), query.getCategory())) {
                                     newTab.setInitialName(loadedQuery.getName() + " - unfolded");
                                     loadedQuery.copyOptions(dataLayerQuery);
                                     newTab.addQuery(loadedQuery);

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPN.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPN.java
@@ -331,7 +331,7 @@ public class VerifyPN implements ModelChecker {
                         }
                     } catch (FormatException e) {
                         e.printStackTrace();
-                    } catch (ThreadDeath d) {
+                    } catch (NullPointerException | ThreadDeath n) {
                         return null;
                     }
                 }

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPN.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPN.java
@@ -319,7 +319,7 @@ public class VerifyPN implements ModelChecker {
                                 newTab = new PetriNetTab(loadedModel.network(), loadedModel.templates(), loadedModel.queries(), new TAPNLens(lens.isTimed(), lens.isGame(), false));
 
                                 //The query being verified should be the only query
-                                for (net.tapaal.gui.petrinet.verification.TAPNQuery loadedQuery : UnfoldNet.getQueries(queriesOut, loadedModel.network())) {
+                                for (net.tapaal.gui.petrinet.verification.TAPNQuery loadedQuery : UnfoldNet.getQueries(queriesOut, loadedModel.network(), query.getCategory())) {
                                     newTab.setInitialName(loadedQuery.getName() + " - unfolded");
                                     loadedQuery.copyOptions(dataLayerQuery);
                                     newTab.addQuery(loadedQuery);

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPN.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPN.java
@@ -308,7 +308,7 @@ public class VerifyTAPN implements ModelChecker {
                                 newTab = new PetriNetTab(loadedModel.network(), loadedModel.templates(), loadedModel.queries(), new TAPNLens(lens.isTimed(), lens.isGame(), false));
 
                                 //The query being verified should be the only query
-                                for (net.tapaal.gui.petrinet.verification.TAPNQuery loadedQuery : UnfoldNet.getQueries(queriesOut, loadedModel.network())) {
+                                for (net.tapaal.gui.petrinet.verification.TAPNQuery loadedQuery : UnfoldNet.getQueries(queriesOut, loadedModel.network(), query.getCategory())) {
                                     newTab.setInitialName(loadedQuery.getName() + " - unfolded");
                                     loadedQuery.copyOptions(dataLayerQuery);
                                     newTab.addQuery(loadedQuery);

--- a/src/main/java/net/tapaal/gui/petrinet/verification/RunVerificationBase.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/RunVerificationBase.java
@@ -73,8 +73,7 @@ public abstract class RunVerificationBase extends SwingWorker<VerificationResult
     public void execute(VerificationOptions options, TimedArcPetriNetNetwork model, TAPNQuery query, net.tapaal.gui.petrinet.verification.TAPNQuery dataLayerQuery) {
         execute(options, model, query, dataLayerQuery, null);
     }
-
-
+    
 	@Override
 	protected VerificationResult<TAPNNetworkTrace> doInBackground() throws Exception {
         ITAPNComposer composer = new TAPNComposer(messenger, guiModels, lens, false, true);
@@ -242,6 +241,7 @@ public abstract class RunVerificationBase extends SwingWorker<VerificationResult
 			}
 			firePropertyChange("state", StateValue.PENDING, StateValue.DONE);
 
+			if (result == null) return;
 			if (showResult(result) && spinner != null) {
 			    options = new VerifyPNOptions(options.extraTokens(), net.tapaal.gui.petrinet.verification.TAPNQuery.TraceOption.NONE, SearchOption.BFS, false, ModelReduction.BOUNDPRESERVING, false, false, 1, net.tapaal.gui.petrinet.verification.TAPNQuery.QueryCategory.Default, net.tapaal.gui.petrinet.verification.TAPNQuery.AlgorithmOption.CERTAIN_ZERO, false, net.tapaal.gui.petrinet.verification.TAPNQuery.QueryReductionTime.NoTime, false, null, false, false, false, false, false, false, false);
                 // XXX: needs refactoring, will only work if the model verified in the one on top (using getCurrentTab)

--- a/src/main/java/net/tapaal/gui/petrinet/verification/UnfoldNet.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/UnfoldNet.java
@@ -232,8 +232,8 @@ public class UnfoldNet extends SwingWorker<String, Void> {
         return null;
     }
 
-    public static List<TAPNQuery> getQueries(File queryFile, TimedArcPetriNetNetwork network) {
-        return getQueries(queryFile, network, null);
+    public static List<TAPNQuery> getQueries(File queryFile, TimedArcPetriNetNetwork network, TAPNQuery.QueryCategory queryCategory) {
+        return getQueries(queryFile, network, List.of(queryCategory));
     }
     public static List<TAPNQuery> getQueries(File queryFile, TimedArcPetriNetNetwork network, List<TAPNQuery.QueryCategory> queryCategories) {
         XMLQueryLoader queryLoader = new XMLQueryLoader(queryFile, network, queryCategories);

--- a/src/main/java/net/tapaal/gui/petrinet/verification/UnfoldNet.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/UnfoldNet.java
@@ -199,6 +199,7 @@ public class UnfoldNet extends SwingWorker<String, Void> {
             newTab.setInitialName(oldTab.getTabTitle().replace(".tapn", "") + "-unfolded");
             if(!dummyQuery){
                 for(TAPNQuery query : getQueries(queryOut, loadedModel.network(), queryCategories)){
+                    if (query == null) return null;
                     for(TAPNQuery oldQuery : queries){
                         if(query.getName().equals(oldQuery.getName())){
                             query.copyOptions(oldQuery);
@@ -237,7 +238,11 @@ public class UnfoldNet extends SwingWorker<String, Void> {
     }
     public static List<TAPNQuery> getQueries(File queryFile, TimedArcPetriNetNetwork network, List<TAPNQuery.QueryCategory> queryCategories) {
         XMLQueryLoader queryLoader = new XMLQueryLoader(queryFile, network, queryCategories);
-        return new ArrayList<>(queryLoader.parseQueries().getQueries());
+        try {
+            return new ArrayList<>(queryLoader.parseQueries().getQueries());
+        } catch (NullPointerException e) {
+            return null;
+        }
     }
 
     //XXX: old function to layout the model (before engine supported it)


### PR DESCRIPTION
The query category of the unfolded query is saved in the unfolded query, so no pop-up dialog will ask whether it should be LTL or CTL.

Also fixed null pointer exception appearing when pressing "cancel" in the dialog.

Solves https://bugs.launchpad.net/tapaal/+bug/1960299