### PR TITLE
Changing arc expression 1984074

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AddExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AddExpression.java
@@ -91,7 +91,7 @@ public class AddExpression extends ArcExpression {
     }
 
     @Override
-    public ArcExpression findFirstPlaceHolder() {
+    public Expression findFirstPlaceHolder() {
         for (ArcExpression constituent : constituents) {
             if (constituent.containsPlaceHolder()) {
                 return constituent.findFirstPlaceHolder();

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/ArcExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/ArcExpression.java
@@ -28,7 +28,7 @@ public abstract class ArcExpression extends Expression {
     public abstract ArcExpression deepCopy();
 
     @Override
-    public abstract ArcExpression findFirstPlaceHolder();
+    public abstract Expression findFirstPlaceHolder();
 
 
     public abstract ColorMultiset eval(ExpressionContext context);

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
@@ -117,11 +117,10 @@ public class NumberOfExpression extends ArcExpression {
     }
 
     @Override
-    public ArcExpression findFirstPlaceHolder() {
+    public Expression findFirstPlaceHolder() {
         for (ColorExpression expr : color) {
             if (expr.containsPlaceHolder()) {
-                return null;
-            //  return expr.findFirstPlaceHolder();
+                return expr.findFirstPlaceHolder();
             }
         }
         return null;

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderArcExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderArcExpression.java
@@ -56,7 +56,7 @@ public class PlaceHolderArcExpression extends ArcExpression implements PlaceHold
     }
 
     @Override
-    public ArcExpression findFirstPlaceHolder() {
+    public Expression findFirstPlaceHolder() {
         return this;
     }
 

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/ScalarProductExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/ScalarProductExpression.java
@@ -73,7 +73,7 @@ public class ScalarProductExpression extends ArcExpression {
     }
 
     @Override
-    public ArcExpression findFirstPlaceHolder() {
+    public Expression findFirstPlaceHolder() {
         return expr.findFirstPlaceHolder();
     }
 

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/SubtractExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/SubtractExpression.java
@@ -79,7 +79,7 @@ public class SubtractExpression extends ArcExpression {
     }
 
     @Override
-    public ArcExpression findFirstPlaceHolder() {
+    public Expression findFirstPlaceHolder() {
         if (left.containsPlaceHolder()) {
             return left.findFirstPlaceHolder();
         }

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
@@ -95,10 +95,7 @@ public abstract class ColorComboboxPanel extends JPanel {
     }
 
     public void updateColorType(ColorType ct){
-        updateColorType(ct, null);
-    }
-    public void updateColorType(ColorType ct, Context context){
-        updateColorType(ct, context, false);
+        updateColorType(ct, null, false);
     }
     public void updateColorType(ColorType ct, Context context, boolean includePlaceHolder) {
         removeOldComboBoxes();

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
@@ -679,7 +679,9 @@ public abstract class ColoredArcGuardPanel extends JPanel {
         } else {
             ColorExpression expr;
             Object selectedElement = colorExpressionComboBoxPanel.getColorTypeComboBoxesArray()[0].getSelectedItem();
-            if (selectedElement instanceof String) {
+            if (selectedElement instanceof PlaceHolderColorExpression) {
+                    expr = new PlaceHolderColorExpression();
+            } else if (selectedElement instanceof String) {
                 expr = new AllExpression(colorExpressionComboBoxPanel.getColorType());
             } else if (selectedElement instanceof Variable) {
                 Vector<ColorExpression> currentColor = getColorOfSelection();
@@ -908,7 +910,7 @@ public abstract class ColoredArcGuardPanel extends JPanel {
 
     private void updateNumberExpressionsPanel() {
         Expression current = currentSelection.getObject();
-        colorExpressionComboBoxPanel.updateColorType(selectedColorType,context);
+        colorExpressionComboBoxPanel.updateColorType(selectedColorType, context, true);
         numberExpressionJSpinner.setVisible(!(current instanceof ColorExpression));
         updatingSelection = true;
         if (current instanceof NumberOfExpression) {

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
@@ -472,12 +472,14 @@ public abstract class ColoredArcGuardPanel extends JPanel {
         additionButton.addActionListener(actionEvent -> {
             AddExpression addExpr;
             if (currentSelection.getObject() instanceof ArcExpression) {
-                Vector<ArcExpression> vExpr = new Vector<>();
-                ArcExpression newExpr = new NumberOfExpression((Integer) numberExpressionJSpinner.getValue(), getColorExpression());
+                Vector<ArcExpression> exprArc = new Vector<>();
+                Vector<ColorExpression> exprCol = new Vector<>();
+                exprCol.add(new PlaceHolderColorExpression());
+                ArcExpression newExpr = new NumberOfExpression(1, exprCol);
 
-                vExpr.add((ArcExpression) currentSelection.getObject());
-                vExpr.add(newExpr);
-                addExpr = new AddExpression(vExpr);
+                exprArc.add((ArcExpression) currentSelection.getObject());
+                exprArc.add(newExpr);
+                addExpr = new AddExpression(exprArc);
 
                 UndoableEdit edit = new ColoredArcGuardPanel.ExpressionConstructionEdit(currentSelection.getObject(), addExpr);
                 arcExpression = arcExpression.replace(currentSelection.getObject(), addExpr);
@@ -489,7 +491,9 @@ public abstract class ColoredArcGuardPanel extends JPanel {
         subtractionButton.addActionListener(actionEvent -> {
             SubtractExpression subExpr;
             if (currentSelection.getObject() instanceof ArcExpression) {
-                ArcExpression rightExpr = new NumberOfExpression((Integer) numberExpressionJSpinner.getValue(), getColorExpression());
+                Vector<ColorExpression> exprCol = new Vector<>();
+                exprCol.add(new PlaceHolderColorExpression());
+                ArcExpression rightExpr = new NumberOfExpression(1, exprCol);
                 subExpr = new SubtractExpression((ArcExpression) currentSelection.getObject(), rightExpr);
 
                 UndoableEdit edit = new ColoredArcGuardPanel.ExpressionConstructionEdit(currentSelection.getObject(), subExpr);
@@ -873,7 +877,7 @@ public abstract class ColoredArcGuardPanel extends JPanel {
         currentSelection = position;
 
         updateSelectedColorType();
-        updateNumberExpressionsPanel();
+        updateNumberExpressionsPanel(currentSelection.getObject());
 
         toggleEnabledButtons();
     }
@@ -883,7 +887,7 @@ public abstract class ColoredArcGuardPanel extends JPanel {
 
         ExprStringPosition position;
         if (arcExpression.containsPlaceHolder()) {
-            Expression ae = arcExpression.findFirstPlaceHolder();
+            Expression ae = findParent(arcExpression.findFirstPlaceHolder(), arcExpression);
             position = arcExpression.indexOf(ae);
         }
         else {
@@ -893,10 +897,22 @@ public abstract class ColoredArcGuardPanel extends JPanel {
         currentSelection = position;
 
         updateSelectedColorType();
-        updateNumberExpressionsPanel();
+        updateNumberExpressionsPanel(currentSelection.getObject());
 
         toggleEnabledButtons();
 
+    }
+
+    private Expression findParent (Expression child, Expression parent) {
+        for (ExprStringPosition childCheck : parent.getChildren()) {
+            if (child == childCheck.getObject()) {
+                return parent;
+            } else if (!(childCheck.getObject() instanceof PlaceHolderExpression)) {
+                Expression foundParent = findParent(child, childCheck.getObject());
+                if (foundParent != child) return foundParent;
+            }
+        }
+        return child;
     }
 
     private void updateSelectedColorType(){
@@ -908,8 +924,7 @@ public abstract class ColoredArcGuardPanel extends JPanel {
         }
     }
 
-    private void updateNumberExpressionsPanel() {
-        Expression current = currentSelection.getObject();
+    private void updateNumberExpressionsPanel(Expression current) {
         colorExpressionComboBoxPanel.updateColorType(selectedColorType, context, true);
         numberExpressionJSpinner.setVisible(!(current instanceof ColorExpression));
         updatingSelection = true;
@@ -920,6 +935,8 @@ public abstract class ColoredArcGuardPanel extends JPanel {
             colorExpressionComboBoxPanel.updateSelection(colorExpression);
         } else if (current instanceof ColorExpression) {
             colorExpressionComboBoxPanel.updateSelection(((ColorExpression) current).getBottomColorExpression());
+        } else if (current instanceof ArcExpression) {
+            updateNumberExpressionsPanel(getSpecificChildOfProperty(1, current));
         }
         updatingSelection = false;
     }

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
@@ -691,7 +691,7 @@ public abstract class ColoredArcGuardPanel extends JPanel {
                 }
             } else {
                 Vector<ColorExpression> currentColor = getColorOfSelection();
-                if (currentColor.size() > 0 && currentColor.get(0).toString().contains(selectedElement.toString())) {
+                if (currentColor.size() > 0 && currentColor.get(0).toString().contains(selectedElement.toString()) && !(currentColor.get(0) instanceof AllExpression)) {
                     expr = currentColor.get(0);
                 } else {
                     expr = new UserOperatorExpression((dk.aau.cs.model.CPN.Color) selectedElement);


### PR DESCRIPTION
When changing between dot.all and dot the arc expression will be updated.

Added placeholder in the color selection, so when addition or subtraction is pressed a placeholder will appear on the right side of the expression instead of a copy of the left side.

Solves https://bugs.launchpad.net/tapaal/+bug/1984074.