### PR TITLE
update-query-engine-1984190

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -238,13 +238,13 @@ public class QueryDialog extends JPanel {
 	private final static EngineSupportOptions verifyTAPNOptions= new VerifyTAPNEngineOptions();
     private final static EngineSupportOptions UPPAALCombiOptions= new UPPAALCombiOptions();
     private final static EngineSupportOptions UPPAALOptimizedStandardOptions = new UPPAALOptimizedStandardOptions();
-    private final static EngineSupportOptions UPPAAALStandardOptions = new UPPAAALStandardOptions();
+    private final static EngineSupportOptions UPPAALStandardOptions = new UPPAALStandardOptions();
     private final static EngineSupportOptions UPPAALBroadcastOptions = new UPPAALBroadcastOptions();
     private final static EngineSupportOptions UPPAALBroadcastDegree2Options = new UPPAALBroadcastDegree2Options();
     private final static EngineSupportOptions verifyDTAPNOptions= new VerifyDTAPNEngineOptions();
     private final static EngineSupportOptions verifyPNOptions = new VerifyPNEngineOptions();
 
-    private final static EngineSupportOptions[] engineSupportOptions = new EngineSupportOptions[]{verifyDTAPNOptions,verifyTAPNOptions,UPPAALCombiOptions,UPPAALOptimizedStandardOptions,UPPAAALStandardOptions,UPPAALBroadcastOptions,UPPAALBroadcastDegree2Options,verifyPNOptions};
+    private final static EngineSupportOptions[] engineSupportOptions = new EngineSupportOptions[]{verifyDTAPNOptions,verifyTAPNOptions,UPPAALCombiOptions,UPPAALOptimizedStandardOptions, UPPAALStandardOptions,UPPAALBroadcastOptions,UPPAALBroadcastDegree2Options,verifyPNOptions};
 
     private TCTLAbstractProperty newProperty;
 	private JTextField queryName;

--- a/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALStandardOptions.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALStandardOptions.java
@@ -1,8 +1,8 @@
 package net.tapaal.gui.petrinet.verification;
 
-public class UPPAAALStandardOptions extends EngineSupportOptions {
+public class UPPAALStandardOptions extends EngineSupportOptions {
 
-    public UPPAAALStandardOptions() {
+    public UPPAALStandardOptions() {
         super (
             "UPPAAL: Standard Reduction",//name of engine
             false,//  support fastest trace

--- a/src/main/java/net/tapaal/gui/petrinet/widgets/QueryPane.java
+++ b/src/main/java/net/tapaal/gui/petrinet/widgets/QueryPane.java
@@ -23,8 +23,11 @@ import javax.swing.ListSelectionModel;
 import javax.swing.event.ListDataEvent;
 import javax.swing.event.ListDataListener;
 
+import dk.aau.cs.TCTL.*;
+import dk.aau.cs.model.tapn.TimedArcPetriNetNetwork;
 import net.tapaal.gui.petrinet.undo.MoveElementDownCommand;
 import net.tapaal.gui.petrinet.undo.MoveElementUpCommand;
+import net.tapaal.gui.petrinet.verification.EngineSupportOptions;
 import net.tapaal.resourcemanager.ResourceManager;
 import net.tapaal.gui.petrinet.verification.TAPNQuery;
 import pipe.gui.MessengerImpl;
@@ -450,8 +453,7 @@ public class QueryPane extends JPanel implements SidePane {
 	private void verifyQuery() {
 		TAPNQuery query = queryList.getSelectedValue();
 		int NumberOfSelectedElements = queryList.getSelectedIndices().length;
-		
-		
+
 		if(NumberOfSelectedElements == 1) {
 			if(query.getReductionOption() == ReductionOption.VerifyTAPN || query.getReductionOption() == ReductionOption.VerifyDTAPN || query.getReductionOption() == ReductionOption.VerifyPN)
 				Verifier.runVerifyTAPNVerification(tabContent.network(), query, null, tabContent.getGuiModels(), false, tabContent.lens);


### PR DESCRIPTION
When converting the net to another type, the currently selected engine is checked. If its not supported, the engine selection will be updated with one that is supported.

Solves https://bugs.launchpad.net/tapaal/+bug/1984190