### PR TITLE
Only xml queries 1984064

### DIFF
--- a/src/main/java/dk/aau/cs/TCTL/visitors/LTLQueryVisitor.java
+++ b/src/main/java/dk/aau/cs/TCTL/visitors/LTLQueryVisitor.java
@@ -70,6 +70,10 @@ public class LTLQueryVisitor extends VisitorBase {
         return formatter.format(getStartTag() + xmlQuery.toString() + getEndTag());
     }
 
+    public StringBuffer getXMLQuery() {
+        return xmlQuery;
+    }
+
     public String getStartTag(){
         return startTag(XML_PROPSET + " " + XML_NS) + "\n";
     }

--- a/src/main/java/dk/aau/cs/io/TapnEngineXmlLoader.java
+++ b/src/main/java/dk/aau/cs/io/TapnEngineXmlLoader.java
@@ -115,23 +115,14 @@ public class TapnEngineXmlLoader {
             }
         }
 		network.buildConstraints();
-		
-		parseBound(doc, network);
-
 		parseFeature(doc, network);
+		network.setDefaultBound(3); // Ignores k-bounds in .tapn files
 
         if (hasFeatureTag) {
             return new LoadedModel(network, templates, loadedQueries.getQueries(), messages, lens);
         } else {
             return new LoadedModel(network, templates, loadedQueries.getQueries(), messages, null);
         }
-	}
-
-	private void parseBound(Document doc, TimedArcPetriNetNetwork network){
-		if(doc.getElementsByTagName("k-bound").getLength() > 0){
-			int i = Integer.parseInt(doc.getElementsByTagName("k-bound").item(0).getAttributes().getNamedItem("bound").getNodeValue());
-			network.setDefaultBound(i);
-		}
 	}
 
     private void parseFeature(Document doc, TimedArcPetriNetNetwork network) {

--- a/src/main/java/dk/aau/cs/io/TapnXmlLoader.java
+++ b/src/main/java/dk/aau/cs/io/TapnXmlLoader.java
@@ -141,7 +141,6 @@ public class TapnXmlLoader {
 	private LoadedModel parse(Document doc) throws FormatException {
 		idResolver.clear();
 
-
 		ConstantStore constants = new ConstantStore(parseConstants(doc));
 		TimedArcPetriNetNetwork network = new TimedArcPetriNetNetwork(constants, new ArrayList<>());
         NodeList declarations = doc.getElementsByTagName("declaration");
@@ -173,23 +172,14 @@ public class TapnXmlLoader {
             }
         }
 		network.buildConstraints();
-		
-		parseBound(doc, network);
-
 		parseFeature(doc, network);
+        network.setDefaultBound(3); // Ignores k-bounds in .tapn files
 
         if (hasFeatureTag) {
             return new LoadedModel(network, templates, loadedQueries.getQueries(), messages, lens);
         } else {
             return new LoadedModel(network, templates, loadedQueries.getQueries(), messages, null);
         }
-	}
-
-	private void parseBound(Document doc, TimedArcPetriNetNetwork network){
-		if(doc.getElementsByTagName("k-bound").getLength() > 0){
-			int i = Integer.parseInt(doc.getElementsByTagName("k-bound").item(0).getAttributes().getNamedItem("bound").getNodeValue());
-			network.setDefaultBound(i);
-		}
 	}
 
     private void parseFeature(Document doc, TimedArcPetriNetNetwork network) {

--- a/src/main/java/dk/aau/cs/io/TimedArcPetriNetNetworkWriter.java
+++ b/src/main/java/dk/aau/cs/io/TimedArcPetriNetNetworkWriter.java
@@ -302,12 +302,10 @@ public class TimedArcPetriNetNetworkWriter implements NetWriter {
 	private void appendQueries(Document document, Element root) {
 		for (TAPNQuery query : queries) {
 			Element newQuery;
-			if (query.getCategory() == QueryCategory.CTL){
-				newQuery = createCTLQueryElement(query, document);
-			} else if (query.getCategory() == QueryCategory.LTL){
+			if (query.getCategory() == QueryCategory.LTL){
 			    newQuery = createLTLQueryElement(query, document);
-            }else {
-				newQuery = createQueryElement(query, document);
+            } else {
+                newQuery = createCTLQueryElement(query, document);
 			}
 			root.appendChild(newQuery);
 		}

--- a/src/main/java/dk/aau/cs/io/TimedArcPetriNetNetworkWriter.java
+++ b/src/main/java/dk/aau/cs/io/TimedArcPetriNetNetworkWriter.java
@@ -390,7 +390,10 @@ public class TimedArcPetriNetNetworkWriter implements NetWriter {
 
         Element queryElement = document.createElement("query");
 
-        Node queryFormula = XMLQueryStringToElement(new LTLQueryVisitor().getXMLQueryFor(query.getProperty(), query.getName()));
+        LTLQueryVisitor ltlQueryVisitor = new LTLQueryVisitor();
+        ltlQueryVisitor.buildXMLQuery(query.getProperty(), query.getName());
+
+        Node queryFormula = XMLQueryStringToElement(ltlQueryVisitor.getXMLQuery().toString());
         queryElement.appendChild(document.importNode(queryFormula, true));
 
         queryElement.setAttribute("name", query.getName());

--- a/src/main/java/dk/aau/cs/io/TimedArcPetriNetNetworkWriter.java
+++ b/src/main/java/dk/aau/cs/io/TimedArcPetriNetNetworkWriter.java
@@ -114,7 +114,6 @@ public class TimedArcPetriNetNetworkWriter implements NetWriter {
 		appendTemplates(document, pnmlRootNode);
 
         appendQueries(document, pnmlRootNode);
-		appendDefaultBound(document, pnmlRootNode);
 		appendFeature(document, pnmlRootNode);
 
 		document.normalize();
@@ -160,12 +159,6 @@ public class TimedArcPetriNetNetworkWriter implements NetWriter {
 							+ file.getCanonicalPath()
 							+ "\"" + e);
 		}
-	}
-	
-	private void appendDefaultBound(Document document, Element root) {
-		Element element = document.createElement("k-bound");
-		element.setAttribute("bound", network.getDefaultBound() + "");
-		root.appendChild(element);
 	}
 
     private void appendFeature(Document document, Element root) {

--- a/src/main/java/dk/aau/cs/io/TimedArcPetriNetNetworkWriter.java
+++ b/src/main/java/dk/aau/cs/io/TimedArcPetriNetNetworkWriter.java
@@ -352,7 +352,10 @@ public class TimedArcPetriNetNetworkWriter implements NetWriter {
 
 		Element queryElement = document.createElement("query");
 
-		Node queryFormula = XMLQueryStringToElement(new CTLQueryVisitor().getXMLQueryFor(query.getProperty(), query.getName(), false));
+		CTLQueryVisitor ctlQueryVisitor = new CTLQueryVisitor();
+		ctlQueryVisitor.buildXMLQuery(query.getProperty(), query.getName(), false);
+
+		Node queryFormula = XMLQueryStringToElement(ctlQueryVisitor.getXMLQuery().toString());
 		queryElement.appendChild(document.importNode(queryFormula, true));
 		
 		queryElement.setAttribute("name", query.getName());

--- a/src/main/java/dk/aau/cs/verification/TAPNComposer.java
+++ b/src/main/java/dk/aau/cs/verification/TAPNComposer.java
@@ -116,7 +116,7 @@ public class TAPNComposer implements ITAPNComposer {
 	}
 
 	private boolean isComponentEmpty(DataLayer guiModel) {
-		return guiModel.getPlaces().length == 0 && guiModel.getTransitions().length == 0;
+		return guiModel == null || guiModel.getPlaces().length == 0 && guiModel.getTransitions().length == 0;
 	}
         
 	private PlaceTransitionObject getRightmostObject(DataLayer guiModel) {

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNExporter.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNExporter.java
@@ -67,9 +67,6 @@ public class VerifyTAPNExporter {
 			PrintStream queryStream = new PrintStream(queryFile);
             if (query == null) {
                 throw new FileNotFoundException(null);
-            } else if (query.getCategory() == QueryCategory.CTL && (lens == null || !lens.isGame())) {
-                CTLQueryVisitor XMLVisitor = new CTLQueryVisitor();
-                queryStream.append(XMLVisitor.getXMLQueryFor(query.getProperty(), dataLayerQuery == null? model.name() : dataLayerQuery.getName(), false));
             } else if (query.getCategory() == QueryCategory.LTL) {
                 LTLQueryVisitor XMLVisitor = new LTLQueryVisitor();
                 queryStream.append(XMLVisitor.getXMLQueryFor(query.getProperty(), null));
@@ -77,7 +74,8 @@ public class VerifyTAPNExporter {
                 CTLQueryVisitor XMLVisitor = new CTLQueryVisitor();
                 queryStream.append(XMLVisitor.getXMLQueryFor(query.getProperty(), null, true));
             } else {
-                queryStream.append(query.getProperty().toString());
+                CTLQueryVisitor XMLVisitor = new CTLQueryVisitor();
+                queryStream.append(XMLVisitor.getXMLQueryFor(query.getProperty(), dataLayerQuery == null? model.name() : dataLayerQuery.getName(), false));
             }
 			queryStream.close();
 		} catch(FileNotFoundException e) {

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNExporter.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNExporter.java
@@ -32,14 +32,8 @@ public class VerifyTAPNExporter {
     protected TimedArcPetriNet model;
 	public ExportedVerifyTAPNModel export(TimedArcPetriNet model, TAPNQuery query, TAPNLens lens, NameMapping mapping, DataLayer guiModel, net.tapaal.gui.petrinet.verification.TAPNQuery dataLayerQuery) {
 		File modelFile = createTempFile(".xml");
-		File queryFile;
-		if (query.getCategory() == QueryCategory.CTL || query.getCategory() == QueryCategory.LTL || (lens != null && !lens.isGame() && lens.isColored())) {
-			queryFile = createTempFile(".xml");
-		} else {
-			queryFile = createTempFile(".q");
-		}
+		File queryFile = createTempFile(".xml");
 		this.model = model;
-
 		return export(model, query, modelFile, queryFile, dataLayerQuery, lens, mapping, guiModel);
 	}
 

--- a/src/main/java/pipe/gui/petrinet/Export.java
+++ b/src/main/java/pipe/gui/petrinet/Export.java
@@ -152,9 +152,9 @@ public class Export {
             i++;
 
             if (lens.isGame() && isDTAPN) {
-                exporter.export(model, new dk.aau.cs.model.tapn.TAPNQuery(query.getProperty(), 0), new File(modelFile), new File(queryFile + i + ".q"), null, lens, transformedModel.value2(), composer.getGuiModel());
+                exporter.export(model, new dk.aau.cs.model.tapn.TAPNQuery(query.getProperty(), 0), new File(modelFile), new File(queryFile + i + ".xml"), null, lens, transformedModel.value2(), composer.getGuiModel());
             } else {
-                exporter.export(model, new dk.aau.cs.model.tapn.TAPNQuery(query.getProperty(), 0), new File(modelFile), new File(queryFile + i + ".q"), null ,new TAPNLens(true, false, lens.isColored()), transformedModel.value2(), composer.getGuiModel());
+                exporter.export(model, new dk.aau.cs.model.tapn.TAPNQuery(query.getProperty(), 0), new File(modelFile), new File(queryFile + i + ".xml"), null, new TAPNLens(true, false, lens.isColored()), transformedModel.value2(), composer.getGuiModel());
             }
         }
     }


### PR DESCRIPTION
When exporting, saving, or verifying the queries will be converted to XML format instead of text. They will also have the .xml ending.

Importing and opening can still accept text and xml formats.

Solves https://bugs.launchpad.net/tapaal/+bug/1984064.