### PR TITLE
Checks tuples properly before editing a product color type

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/TupleExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/TupleExpression.java
@@ -42,7 +42,17 @@ public class TupleExpression extends ColorExpression {
 
     @Override
     public boolean containsColor(Color color) {
-        return equals(color);
+        boolean containsColor = false;
+        Vector<Color> tuple = color.getTuple();
+        if (tuple != null && tuple.size() == colors.size()) {
+            containsColor = true;
+            for (int i = 0; i < tuple.size(); i++) {
+                if (!colors.get(i).containsColor(tuple.get(i)))
+                    containsColor = false;
+                    break;
+            }
+        }
+        return containsColor || equals(color);
     }
 
     @Override

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
@@ -613,7 +613,7 @@ public class ColorTypeDialogPanel extends JPanel {
         }
 
         if (!messages.isEmpty()) {
-            String message = "Colortype cannot have colors removed for the following reasons: \n\n";
+            String message = "Color type cannot have colors removed for the following reasons: \n\n";
             for (String m : messages) {
                 if (!message.contains(m)) message += m;
             }
@@ -822,9 +822,9 @@ public class ColorTypeDialogPanel extends JPanel {
                 productColorTypeList.setModel(productModel);
                 productRemoveButton.setEnabled(true);
             }else{
-                String message = "Colortype cannot have colors removed for the following reasons: \n\n";
+                String message = "Color type cannot have colors added for the following reasons: \n\n";
                 message += String.join("", messages);
-                JOptionPane.showMessageDialog(TAPAALGUI.getApp(), message, "Could not remove color from color type", JOptionPane.WARNING_MESSAGE);
+                JOptionPane.showMessageDialog(TAPAALGUI.getApp(), message, "Could not add color from color type", JOptionPane.WARNING_MESSAGE);
             }
         });
 
@@ -955,7 +955,7 @@ public class ColorTypeDialogPanel extends JPanel {
             }
 
             if(!messages.isEmpty()) {
-                String message = "Colortype cannot have the following colors removed for the following reasons: \n\n";
+                String message = "Color type cannot have the following colors removed for the following reasons: \n\n";
                 message += String.join("", messages);
                 JOptionPane.showMessageDialog(TAPAALGUI.getApp(), message, "Could not remove color from color type", JOptionPane.WARNING_MESSAGE);
                 return;

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
@@ -613,7 +613,7 @@ public class ColorTypeDialogPanel extends JPanel {
         }
 
         if (!messages.isEmpty()) {
-            String message = "Color type cannot be modified for the following reasons: \n\n";
+            String message = "The color type cannot be modified for the following reasons: \n\n";
             for (String m : messages) {
                 if (!message.contains(m)) message += m;
             }
@@ -822,7 +822,7 @@ public class ColorTypeDialogPanel extends JPanel {
                 productColorTypeList.setModel(productModel);
                 productRemoveButton.setEnabled(true);
             }else{
-                String message = "Color type cannot be modified for the following reasons: \n\n";
+                String message = "The color type cannot be modified for the following reasons: \n\n";
                 message += String.join("", messages);
                 JOptionPane.showMessageDialog(TAPAALGUI.getApp(), message, "Could not add color from color type", JOptionPane.WARNING_MESSAGE);
             }
@@ -955,7 +955,7 @@ public class ColorTypeDialogPanel extends JPanel {
             }
 
             if(!messages.isEmpty()) {
-                String message = "Color type cannot be modified for the following reasons: \n\n";
+                String message = "The color type cannot be modified for the following reasons: \n\n";
                 message += String.join("", messages);
                 JOptionPane.showMessageDialog(TAPAALGUI.getApp(), message, "Could not remove color from color type", JOptionPane.WARNING_MESSAGE);
                 return;

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
@@ -613,7 +613,7 @@ public class ColorTypeDialogPanel extends JPanel {
         }
 
         if (!messages.isEmpty()) {
-            String message = "Color type cannot have colors removed for the following reasons: \n\n";
+            String message = "Color type cannot be modified for the following reasons: \n\n";
             for (String m : messages) {
                 if (!message.contains(m)) message += m;
             }
@@ -822,7 +822,7 @@ public class ColorTypeDialogPanel extends JPanel {
                 productColorTypeList.setModel(productModel);
                 productRemoveButton.setEnabled(true);
             }else{
-                String message = "Color type cannot have colors added for the following reasons: \n\n";
+                String message = "Color type cannot be modified for the following reasons: \n\n";
                 message += String.join("", messages);
                 JOptionPane.showMessageDialog(TAPAALGUI.getApp(), message, "Could not add color from color type", JOptionPane.WARNING_MESSAGE);
             }
@@ -955,7 +955,7 @@ public class ColorTypeDialogPanel extends JPanel {
             }
 
             if(!messages.isEmpty()) {
-                String message = "Color type cannot have the following colors removed for the following reasons: \n\n";
+                String message = "Color type cannot be modified for the following reasons: \n\n";
                 message += String.join("", messages);
                 JOptionPane.showMessageDialog(TAPAALGUI.getApp(), message, "Could not remove color from color type", JOptionPane.WARNING_MESSAGE);
                 return;

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -683,8 +683,8 @@ public class ColoredTransitionGuardPanel  extends JPanel {
     }
 
     private void checkSelectionComparison() {
-        if (currentSelection.getObject() instanceof GreaterThanEqExpression || currentSelection.getObject() instanceof GreaterThanExpression ||
-            currentSelection.getObject() instanceof LessThanEqExpression || currentSelection.getObject() instanceof LessThanExpression) {
+        if (currentSelection != null && (currentSelection.getObject() instanceof GreaterThanEqExpression || currentSelection.getObject() instanceof GreaterThanExpression ||
+            currentSelection.getObject() instanceof LessThanEqExpression || currentSelection.getObject() instanceof LessThanExpression)) {
             deleteSelection();
         }
     }


### PR DESCRIPTION
When editing a product color used on a transition guard, it is not possible to remove or add colors to the tuple.

Solves https://bugs.launchpad.net/tapaal/+bug/1985048