### PR TITLE
fix-arc-dialog-1985880

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
@@ -95,14 +95,17 @@ public abstract class ColorComboboxPanel extends JPanel {
     }
 
     public void updateColorType(ColorType ct){
-        updateColorType(ct, null, false);
+        updateColorType(ct, null, false, false);
     }
-    public void updateColorType(ColorType ct, Context context, boolean includePlaceHolder) {
+    public void updateColorType(ColorType ct, boolean transitionDialog){
+        updateColorType(ct, null, false, transitionDialog);
+    }
+    public void updateColorType(ColorType ct, Context context, boolean includePlaceHolder, boolean transitionDialog) {
         removeOldComboBoxes();
         colorType = ct;
 
         if (colorType instanceof ProductType) {
-            int numberOfComBoboxes = includePlaceHolder ? 1 : ((ProductType) colorType).getColorTypes().size();
+            int numberOfComBoboxes =  transitionDialog ? 1 : ((ProductType) colorType).getColorTypes().size();
             colorTypeComboBoxesArray = new JComboBox[numberOfComBoboxes];
 
             for (int i = 0; i < colorTypeComboBoxesArray.length; i++) {

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -735,7 +735,7 @@ public class ColoredTransitionGuardPanel  extends JPanel {
                     newColorType = ((ProductType) ct).getConstituents().firstElement();
                 else
                     newColorType = ((ProductType) ct).getConstituents().get(((ColorExpression) currentSelection.getObject()).getIndex());
-                colorCombobox.updateColorType(newColorType, context, true);
+                colorCombobox.updateColorType(newColorType, context, true, true);
             }
             ColorExpression exprToCheck = ((ColorExpression) currentSelection.getObject()).getBottomColorExpression();
             colorCombobox.updateSelection(exprToCheck);
@@ -882,7 +882,7 @@ public class ColoredTransitionGuardPanel  extends JPanel {
     private void updateColorType() {
         ColorType ct = colorTypeCombobox.getItemAt(colorTypeCombobox.getSelectedIndex());
         if (ct != null) {
-            colorCombobox.updateColorType(ct, context, true);
+            colorCombobox.updateColorType(ct, context, true, true);
         }
         updateEnabledButtons();
         if (doColorTypeUndo) updateExpression();


### PR DESCRIPTION
Fixes exception caused by product types not handled properly in the arc dialog.

Solves https://bugs.launchpad.net/tapaal/+bug/1985880.