### PR TITLE
product-remove-dot-1985989

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
@@ -168,7 +168,6 @@ public class ColorTypeDialogPanel extends JPanel {
         gbc.insets = new Insets(5, 8, 0, 8);
         container.add(productTypePanel, gbc);
 
-
         JPanel buttonPanel = createButtonPanel();
         gbc.insets = new Insets(0, 8, 5, 8);
         gbc.gridx = 0;
@@ -680,7 +679,6 @@ public class ColorTypeDialogPanel extends JPanel {
 
         productModel = new DefaultListModel();
 
-
         colorTypes = new ArrayList<>();
         colorTypes = network.colorTypes();
 
@@ -688,9 +686,12 @@ public class ColorTypeDialogPanel extends JPanel {
         productTypeComboBox.setRenderer(new ColortypeListCellRenderer());
 
         for (ColorType element : colorTypes) {
-            if(!(element instanceof ProductType)){
+            if (!(element instanceof ProductType) && element != ColorType.COLORTYPE_DOT) {
                 productTypeComboBox.addItem(element);
             }
+        }
+        if (productTypeComboBox.getItemCount() == 0) {
+            colorTypeComboBox.removeItem(productColor);
         }
 
         gbc.insets = new Insets(2, 4, 2, 4);


### PR DESCRIPTION
When creating a new product color type, the dot type is not shown in the product color selection. If the dot type is the only color, then the option to create a new product type is removed.

Solves https://bugs.launchpad.net/tapaal/+bug/1985989.