### PR TITLE
shorten-color-types

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorTypeDialogPanel.java
@@ -722,6 +722,7 @@ public class ColorTypeDialogPanel extends JPanel {
         JPanel scrollPanePanel = new JPanel();
         scrollPanePanel.setLayout(new GridBagLayout());
         productColorTypeList = new JList();
+        productColorTypeList.setCellRenderer(new ColortypeListCellRenderer());
         productColorTypeList.addListSelectionListener(e -> {
             if (!e.getValueIsAdjusting()) {
                 JList source = (JList) e.getSource();


### PR DESCRIPTION
Color types with many colors are shortened with "..." when displayed in the product color type dialog