### PR TITLE
Invalid transition comparison 1986788

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AllExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AllExpression.java
@@ -25,6 +25,7 @@ public class AllExpression extends ColorExpression {
     }
 
     public AllExpression(ColorType sort) {
+        super(sort);
         this.sort = sort;
     }
 

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AllExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AllExpression.java
@@ -132,7 +132,7 @@ public class AllExpression extends ColorExpression {
     }
 
     @Override
-    public Vector<ColorType> getColorTypes(){
+    public Vector<ColorType> getColorTypes() {
         return new Vector<>(Collections.singletonList(sort));
     }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/ColorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/ColorExpression.java
@@ -12,9 +12,10 @@ public abstract class ColorExpression extends Expression {
 
     protected ColorExpression parent;
     protected int index = -1;
+    protected ColorType colorType;
 
-    public ColorExpression() {
-
+    public ColorExpression(ColorType colorType) {
+        this.colorType = colorType;
     }
 
     @Override
@@ -41,7 +42,7 @@ public abstract class ColorExpression extends Expression {
 
     public abstract boolean hasVariable(List<Variable> variables);
 
-    public abstract ColorType getColorType(List<ColorType> colortypes);
+    public ColorType getColorType() { return colorType; }
 
     public abstract boolean isComparable(ColorExpression otherExpr);
 

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/DotConstantExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/DotConstantExpression.java
@@ -97,6 +97,6 @@ public class DotConstantExpression extends UserOperatorExpression {
 
     @Override
     public Vector<ColorType> getColorTypes() {
-        return new Vector<>(Collections.singletonList(ColorType.COLORTYPE_DOT));
+        return new Vector<>(Collections.singletonList(colorType));
     }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/DotConstantExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/DotConstantExpression.java
@@ -35,11 +35,6 @@ public class DotConstantExpression extends UserOperatorExpression {
         return false;
     }
 
-    @Override
-    public ColorType getColorType(List<ColorType> colorTypes) {
-        return getColorType();
-    }
-
     public ColorType getColorType() {
         return ColorType.COLORTYPE_DOT;
     }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/EqualityExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/EqualityExpression.java
@@ -1,19 +1,24 @@
 package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.Color;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprStringPosition;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
 
 import java.util.Set;
 
-public class EqualityExpression extends GuardExpression implements LeftRightGuardExpression{
+public class EqualityExpression extends GuardExpression implements LeftRightGuardExpression {
     private ColorExpression left;
     private ColorExpression right;
 
     public EqualityExpression(ColorExpression left, ColorExpression right) {
+        this(left, right, null);
+    }
+    public EqualityExpression(ColorExpression left, ColorExpression right, ColorType colorType) {
         this.left = left;
         this.right = right;
+        this.colorType = colorType;
     }
     public ColorExpression getLeftExpression() {
         return this.left;
@@ -40,6 +45,7 @@ public class EqualityExpression extends GuardExpression implements LeftRightGuar
         else {
             left = left.replace( object1, object2, replaceAllInstances);
             right = right.replace(object1, object2, replaceAllInstances);
+            colorType = left.getColorType();
             return this;
         }
     }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/GreaterThanEqExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/GreaterThanEqExpression.java
@@ -1,20 +1,25 @@
 package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.Color;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprStringPosition;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
 
 import java.util.Set;
 
-public class GreaterThanEqExpression extends GuardExpression implements LeftRightGuardExpression{
+public class GreaterThanEqExpression extends GuardExpression implements LeftRightGuardExpression {
 
     private ColorExpression left;
     private ColorExpression right;
 
     public GreaterThanEqExpression(ColorExpression left, ColorExpression right) {
+        this(left, right, null);
+    }
+    public GreaterThanEqExpression(ColorExpression left, ColorExpression right, ColorType colorType) {
         this.left = left;
         this.right = right;
+        this.colorType = colorType;
     }
     public ColorExpression getLeftExpression() {
         return this.left;
@@ -42,6 +47,7 @@ public class GreaterThanEqExpression extends GuardExpression implements LeftRigh
         else {
             left = left.replace(object1, object2,replaceAllInstances);
             right = right.replace(object1, object2,replaceAllInstances);
+            colorType = left.getColorType();
             return this;
         }
     }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/GreaterThanExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/GreaterThanExpression.java
@@ -1,19 +1,24 @@
 package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.Color;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprStringPosition;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
 
 import java.util.Set;
 
-public class GreaterThanExpression extends GuardExpression implements LeftRightGuardExpression{
+public class GreaterThanExpression extends GuardExpression implements LeftRightGuardExpression {
     private ColorExpression left;
     private ColorExpression right;
 
     public GreaterThanExpression(ColorExpression left, ColorExpression right) {
+        this(left, right, null);
+    }
+    public GreaterThanExpression(ColorExpression left, ColorExpression right, ColorType colorType) {
         this.left = left;
         this.right = right;
+        this.colorType = colorType;
     }
     public ColorExpression getLeftExpression() {
         return this.left;
@@ -46,6 +51,7 @@ public class GreaterThanExpression extends GuardExpression implements LeftRightG
         else {
             left = left.replace(object1, object2,replaceAllInstances);
             right = right.replace(object1, object2,replaceAllInstances);
+            colorType = left.getColorType();
             return this;
         }
     }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/GuardExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/GuardExpression.java
@@ -1,5 +1,6 @@
 package dk.aau.cs.model.CPN.Expressions;
 
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.Variable;
 
 import java.util.Set;
@@ -7,14 +8,15 @@ import java.util.Set;
 public abstract class GuardExpression extends Expression {
 
     protected GuardExpression parent;
+    protected ColorType colorType;
 
+    public GuardExpression getParent() { return parent; }
+    public void setParent(GuardExpression parent) { this.parent = parent; }
 
-    public GuardExpression getParent() {return parent; }
-
-    public void setParent(GuardExpression parent) {this.parent = parent; }
+    public ColorType getColorType() { return colorType; }
 
     @Override
-    public abstract GuardExpression replace(Expression object1, Expression object2,boolean replaceAllInstances);
+    public abstract GuardExpression replace(Expression object1, Expression object2, boolean replaceAllInstances);
     @Override
     public abstract GuardExpression replace(Expression object1, Expression object2);
 

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/InequalityExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/InequalityExpression.java
@@ -1,6 +1,7 @@
 package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.Color;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprStringPosition;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
@@ -12,8 +13,12 @@ public class InequalityExpression extends GuardExpression implements LeftRightGu
     private ColorExpression right;
 
     public InequalityExpression(ColorExpression left, ColorExpression right) {
+        this(left, right, null);
+    }
+    public InequalityExpression(ColorExpression left, ColorExpression right, ColorType colorType) {
         this.left = left;
         this.right = right;
+        this.colorType = colorType;
     }
     public ColorExpression getLeftExpression() {
         return this.left;
@@ -36,6 +41,7 @@ public class InequalityExpression extends GuardExpression implements LeftRightGu
         else {
             left = left.replace(object1, object2,replaceAllInstances);
             right = right.replace(object1, object2,replaceAllInstances);
+            colorType = left.getColorType();
             return this;
         }
     }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/LessThanEqExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/LessThanEqExpression.java
@@ -2,6 +2,7 @@ package dk.aau.cs.model.CPN.Expressions;
 
 
 import dk.aau.cs.model.CPN.Color;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprStringPosition;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
@@ -13,8 +14,12 @@ public class LessThanEqExpression extends GuardExpression implements LeftRightGu
     private ColorExpression right;
 
     public LessThanEqExpression(ColorExpression left, ColorExpression right) {
+        this(left, right, null);
+    }
+    public LessThanEqExpression(ColorExpression left, ColorExpression right, ColorType colorType) {
         this.left = left;
         this.right = right;
+        this.colorType = colorType;
     }
     public ColorExpression getLeftExpression() {
         return this.left;
@@ -36,6 +41,7 @@ public class LessThanEqExpression extends GuardExpression implements LeftRightGu
         else {
             left = left.replace(object1, object2,replaceAllInstances);
             right = right.replace(object1, object2,replaceAllInstances);
+            colorType = left.getColorType();
             return this;
         }
     }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/LessThanExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/LessThanExpression.java
@@ -1,6 +1,7 @@
 package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.Color;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprStringPosition;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
@@ -13,8 +14,12 @@ public class LessThanExpression extends GuardExpression implements LeftRightGuar
     private ColorExpression right;
 
     public LessThanExpression(ColorExpression left, ColorExpression right) {
+        this(left, right, null);
+    }
+    public LessThanExpression(ColorExpression left, ColorExpression right, ColorType colorType) {
         this.left = left;
         this.right = right;
+        this.colorType = colorType;
     }
     public ColorExpression getLeftExpression() {
         return this.left;
@@ -36,6 +41,7 @@ public class LessThanExpression extends GuardExpression implements LeftRightGuar
         else {
             left = left.replace(object1, object2,replaceAllInstances);
             right = right.replace(object1, object2,replaceAllInstances);
+            colorType = left.getColorType();
             return this;
         }
     }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/NotExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/NotExpression.java
@@ -12,6 +12,7 @@ public class NotExpression extends GuardExpression {
 
     public NotExpression(GuardExpression expr) {
         this.expr = expr;
+        this.colorType = expr.getColorType();
     }
 
     public GuardExpression getExpression() {
@@ -30,6 +31,7 @@ public class NotExpression extends GuardExpression {
         }
         else {
             expr = expr.replace(object1, object2,replaceAllInstances);
+            colorType = expr.getColorType();
             return this;
         }
     }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderColorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderColorExpression.java
@@ -9,6 +9,14 @@ import java.util.*;
 
 public class PlaceHolderColorExpression extends ColorExpression implements PlaceHolderExpression {
 
+    public PlaceHolderColorExpression() {
+        super(null);
+    }
+    // Important to set ColorType if used in ColoredTransitionGuardPanel dialog
+    public PlaceHolderColorExpression(ColorType colorType) {
+        super(colorType);
+    }
+
     @Override
     public List<Color> eval(ExpressionContext context) {
         return List.of();
@@ -27,11 +35,6 @@ public class PlaceHolderColorExpression extends ColorExpression implements Place
     @Override
     public boolean hasVariable(List<Variable> variables) {
         return false;
-    }
-
-    @Override
-    public ColorType getColorType(List<ColorType> colorTypes) {
-        return null;
     }
 
     @Override

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/PredecessorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/PredecessorExpression.java
@@ -16,6 +16,7 @@ public class PredecessorExpression extends ColorExpression {
     }
 
     public  PredecessorExpression(ColorExpression color) {
+        super(color.colorType);
         this.color = color;
     }
 
@@ -42,11 +43,6 @@ public class PredecessorExpression extends ColorExpression {
     @Override
     public boolean hasVariable(List<Variable> variables) {
         return this.color.hasVariable(variables);
-    }
-
-    @Override
-    public ColorType getColorType(List<ColorType> colorTypes) {
-        return color.getColorType(colorTypes);
     }
 
     @Override

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/PredecessorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/PredecessorExpression.java
@@ -116,7 +116,7 @@ public class PredecessorExpression extends ColorExpression {
     }
 
     @Override
-    public Vector<ColorType> getColorTypes(){
+    public Vector<ColorType> getColorTypes() {
         return color.getColorTypes();
     }
 

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/SuccessorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/SuccessorExpression.java
@@ -115,7 +115,7 @@ public class SuccessorExpression extends ColorExpression {
     }
 
     @Override
-    public Vector<ColorType> getColorTypes(){
+    public Vector<ColorType> getColorTypes() {
         return color.getColorTypes();
     }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/SuccessorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/SuccessorExpression.java
@@ -16,6 +16,7 @@ public class SuccessorExpression extends ColorExpression {
     }
 
     public SuccessorExpression(ColorExpression color) {
+        super(color.colorType);
         this.color = color;
     }
 
@@ -42,11 +43,6 @@ public class SuccessorExpression extends ColorExpression {
     @Override
     public boolean hasVariable(List<Variable> variables) {
         return this.color.hasVariable(variables);
-    }
-
-    @Override
-    public ColorType getColorType(List<ColorType> colorTypes) {
-        return color.getColorType(colorTypes);
     }
 
     @Override

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/TupleExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/TupleExpression.java
@@ -17,6 +17,11 @@ public class TupleExpression extends ColorExpression {
     }
 
     public TupleExpression(Vector<ColorExpression> colors) {
+        this(colors, null);
+    }
+    // Important to set ColorType if used in ColoredTransitionGuardPanel dialog
+    public TupleExpression(Vector<ColorExpression> colors, ColorType colorType) {
+        super(colorType);
         this.colors = colors;
         int i = 0;
         for(ColorExpression color : colors){
@@ -81,14 +86,12 @@ public class TupleExpression extends ColorExpression {
         return false;
     }
 
-    @Override
     public ColorType getColorType(List<ColorType> colorTypes) {
         Vector<ColorType> expressionColorTypes = new Vector<>();
 
         for (ColorExpression ce : this.colors) {
-            expressionColorTypes.add(ce.getColorType(colorTypes));
+            expressionColorTypes.add(ce.getColorType());
         }
-
         for (ColorType ct : colorTypes) {
             if (ct instanceof ProductType) {
                 ProductType pt = (ProductType) ct;
@@ -100,6 +103,7 @@ public class TupleExpression extends ColorExpression {
 
         return  null;
     }
+
     @Override
     public boolean isComparable(ColorExpression otherExpr){
         otherExpr = otherExpr.getBottomColorExpression();
@@ -145,7 +149,7 @@ public class TupleExpression extends ColorExpression {
 
     @Override
     public ColorExpression copy() {
-        return new TupleExpression(new Vector<>(colors));
+        return new TupleExpression(new Vector<>(colors), colorType.copy());
     }
 
     @Override
@@ -156,7 +160,7 @@ public class TupleExpression extends ColorExpression {
             colorsCopy.add(expr.deepCopy());
         }
 
-        return new TupleExpression(colorsCopy);
+        return new TupleExpression(colorsCopy, colorType.copy());
     }
 
     @Override

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/TupleExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/TupleExpression.java
@@ -149,7 +149,9 @@ public class TupleExpression extends ColorExpression {
 
     @Override
     public ColorExpression copy() {
-        return new TupleExpression(new Vector<>(colors), colorType.copy());
+        return (colorType == null) ?
+            new TupleExpression(new Vector<>(colors)) :
+            new TupleExpression(new Vector<>(colors), colorType.copy());
     }
 
     @Override
@@ -160,7 +162,9 @@ public class TupleExpression extends ColorExpression {
             colorsCopy.add(expr.deepCopy());
         }
 
-        return new TupleExpression(colorsCopy, colorType.copy());
+        return (colorType == null) ?
+            new TupleExpression(colorsCopy) :
+            new TupleExpression(colorsCopy, colorType.copy());
     }
 
     @Override
@@ -241,9 +245,9 @@ public class TupleExpression extends ColorExpression {
     }
 
     @Override
-    public Vector<ColorType> getColorTypes(){
+    public Vector<ColorType> getColorTypes() {
         Vector<ColorType> constituentColorTypes = new Vector<>();
-        //assumes single level producttypes
+        //assumes single level productTypes
         for(ColorExpression uexpr : getColors()){
             constituentColorTypes.addAll(uexpr.getColorTypes());
         }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/UserOperatorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/UserOperatorExpression.java
@@ -131,7 +131,7 @@ public class UserOperatorExpression extends ColorExpression {
     }
 
     @Override
-    public Vector<ColorType> getColorTypes(){
+    public Vector<ColorType> getColorTypes() {
         return new Vector<>(Collections.singletonList(userOperator.getColorType()));
     }
 

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/UserOperatorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/UserOperatorExpression.java
@@ -19,6 +19,10 @@ public class UserOperatorExpression extends ColorExpression {
     }
 
     public UserOperatorExpression(Color userOperator) {
+        this(userOperator, userOperator.getColorType());
+    }
+    public UserOperatorExpression(Color userOperator, ColorType colorType) {
+        super(colorType);
         this.userOperator = userOperator;
     }
 
@@ -42,11 +46,6 @@ public class UserOperatorExpression extends ColorExpression {
     @Override
     public boolean hasVariable(List<Variable> variables) {
         return false;
-    }
-
-    @Override
-    public ColorType getColorType(List<ColorType> colorTypes) {
-        return userOperator.getColorType();
     }
 
     @Override

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/VariableExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/VariableExpression.java
@@ -17,6 +17,10 @@ public class VariableExpression extends ColorExpression {
     }
 
     public VariableExpression(Variable variable) {
+        this(variable, variable.getColorType());
+    }
+    public VariableExpression(Variable variable, ColorType colorType) {
+        super(colorType);
         this.variable = variable;
     }
 
@@ -43,11 +47,6 @@ public class VariableExpression extends ColorExpression {
             }
         }
         return false;
-    }
-
-    @Override
-    public ColorType getColorType(List<ColorType> colorTypes) {
-        return variable.getColorType();
     }
 
     @Override

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/VariableExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/VariableExpression.java
@@ -171,8 +171,7 @@ public class VariableExpression extends ColorExpression {
     }
 
     @Override
-    public Vector<ColorType> getColorTypes(){
-
+    public Vector<ColorType> getColorTypes() {
         return new Vector<>(Collections.singletonList(variable.getColorType()));
     }
 

--- a/src/main/java/dk/aau/cs/model/CPN/ProductType.java
+++ b/src/main/java/dk/aau/cs/model/CPN/ProductType.java
@@ -50,7 +50,7 @@ public class ProductType extends ColorType {
         }
         return false;
     }
-    public Vector<ColorType> getColorTypes() {return constituents; }
+    public Vector<ColorType> getColorTypes() { return constituents; }
 
     public void addType(ColorType colortype) {
         constituents.add(colortype);

--- a/src/main/java/dk/aau/cs/model/CPN/ProductType.java
+++ b/src/main/java/dk/aau/cs/model/CPN/ProductType.java
@@ -183,6 +183,6 @@ public class ProductType extends ColorType {
         for(ColorType colorType : getColorTypes()){
             tempVec.add(colorType.createColorExpressionForFirstColor());
         }
-        return new TupleExpression(tempVec);
+        return new TupleExpression(tempVec, this);
     }
 }

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
@@ -89,6 +89,10 @@ public abstract class ColorComboboxPanel extends JPanel {
             colorTypeComboBoxesArray[index].setSelectedItem(((UserOperatorExpression)expr).getUserOperator());
         } else if(expr instanceof TupleExpression){
             colorTypeComboBoxesArray[index].setSelectedItem(((TupleExpression)expr).getColors().get(0));
+        } else if (expr instanceof PredecessorExpression) {
+            setIndex(((PredecessorExpression)expr).getPredecessorExpression(), index);
+        } else if (expr instanceof SuccessorExpression) {
+            setIndex(((SuccessorExpression)expr).getSuccessorExpression(), index);
         } else {
             colorTypeComboBoxesArray[index].setSelectedItem(expr);
         }
@@ -96,9 +100,6 @@ public abstract class ColorComboboxPanel extends JPanel {
 
     public void updateColorType(ColorType ct){
         updateColorType(ct, null, false, false);
-    }
-    public void updateColorType(ColorType ct, boolean transitionDialog){
-        updateColorType(ct, null, false, transitionDialog);
     }
     public void updateColorType(ColorType ct, Context context, boolean includePlaceHolder, boolean transitionDialog) {
         removeOldComboBoxes();

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
@@ -1072,7 +1072,9 @@ public abstract class ColoredArcGuardPanel extends JPanel {
 
     private ColorType getCurrentSelectionColorType() {
         if (currentSelection.getObject() instanceof ColorExpression) {
-            return ((ColorExpression) currentSelection.getObject()).getColorType(context.network().colorTypes());
+            ColorType ct = ((ColorExpression) currentSelection.getObject()).getColorType();
+            if (ct == null && currentSelection.getObject() instanceof TupleExpression)
+                return ((TupleExpression) currentSelection.getObject()).getColorType(context.network().colorTypes());
         }
 
         return null;

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
@@ -1075,8 +1075,9 @@ public abstract class ColoredArcGuardPanel extends JPanel {
             ColorType ct = ((ColorExpression) currentSelection.getObject()).getColorType();
             if (ct == null && currentSelection.getObject() instanceof TupleExpression)
                 return ((TupleExpression) currentSelection.getObject()).getColorType(context.network().colorTypes());
+            else
+                return ct;
         }
-
         return null;
     }
 

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -343,56 +343,65 @@ public class ColoredTransitionGuardPanel  extends JPanel {
 
         equalityButton.addActionListener(actionEvent -> {
             var pair = getLeftRightExpression(currentSelection.getObject());
-            replaceAndAddToUndo(currentSelection.getObject(), new EqualityExpression(pair.component1(),pair.component2()));
+            ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+            replaceAndAddToUndo(currentSelection.getObject(), new EqualityExpression(pair.component1(),pair.component2(), type));
 
         });
 
         greaterThanEqButton.addActionListener(actionEvent -> {
             var pair = getLeftRightExpression(currentSelection.getObject());
-            replaceAndAddToUndo(currentSelection.getObject(), new GreaterThanEqExpression(pair.component1(),pair.component2()));
+            ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+            replaceAndAddToUndo(currentSelection.getObject(), new GreaterThanEqExpression(pair.component1(),pair.component2(), type));
 
         });
 
         greaterThanButton.addActionListener(actionEvent -> {
             var pair = getLeftRightExpression(currentSelection.getObject());
-            replaceAndAddToUndo(currentSelection.getObject(), new GreaterThanExpression(pair.component1(),pair.component2()));
+            ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+            replaceAndAddToUndo(currentSelection.getObject(), new GreaterThanExpression(pair.component1(),pair.component2(), type));
 
         });
 
         inequalityButton.addActionListener(actionEvent -> {
             var pair = getLeftRightExpression(currentSelection.getObject());
-            replaceAndAddToUndo(currentSelection.getObject(), new InequalityExpression(pair.component1(),pair.component2()));
+            ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+            replaceAndAddToUndo(currentSelection.getObject(), new InequalityExpression(pair.component1(),pair.component2(), type));
 
         });
         lessThanButton.addActionListener(actionEvent -> {
             var pair = getLeftRightExpression(currentSelection.getObject());
-            replaceAndAddToUndo(currentSelection.getObject(), new LessThanExpression(pair.component1(),pair.component2()));
+            ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+            replaceAndAddToUndo(currentSelection.getObject(), new LessThanExpression(pair.component1(),pair.component2(), type));
         });
 
         lessThanEqButton.addActionListener(actionEvent -> {
             var pair = getLeftRightExpression(currentSelection.getObject());
-            replaceAndAddToUndo(currentSelection.getObject(), new LessThanEqExpression(pair.component1(),pair.component2()));
+            ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+            replaceAndAddToUndo(currentSelection.getObject(), new LessThanEqExpression(pair.component1(),pair.component2(), type));
         });
 
     }
 
     private Vector<ColorExpression> createPlaceholderVectors(int size) {
         Vector<ColorExpression> colorExpressions = new Vector<>();
+        ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
         for (int i = 0; i < size; i++) {
-            colorExpressions.add(new PlaceHolderColorExpression());
+            colorExpressions.add(new PlaceHolderColorExpression(type));
         }
         return colorExpressions;
     }
 
     private Pair<ColorExpression, ColorExpression> getLeftRightExpression(Expression currentSelection) {
         if (currentSelection instanceof PlaceHolderGuardExpression) {
-            if (colorTypeCombobox.getItemAt(colorTypeCombobox.getSelectedIndex()) instanceof ProductType) {
-                int size = ((ProductType) colorTypeCombobox.getItemAt(colorTypeCombobox.getSelectedIndex())).size();
+            if (colorTypeCombobox.getSelectedItem() instanceof ProductType) {
+                int size = ((ProductType) colorTypeCombobox.getSelectedItem()).size();
                 Vector<ColorExpression> tempVec1 = createPlaceholderVectors(size);
                 Vector<ColorExpression> tempVec2 = createPlaceholderVectors(size);
-                return new Pair<>(new TupleExpression(tempVec1), new TupleExpression(tempVec2));
+                return new Pair<>(new TupleExpression(tempVec1, (ProductType) colorTypeCombobox.getSelectedItem()),
+                                  new TupleExpression(tempVec2, (ProductType) colorTypeCombobox.getSelectedItem()));
             }
-            return new Pair<>(new PlaceHolderColorExpression(), new PlaceHolderColorExpression());
+            ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+            return new Pair<>(new PlaceHolderColorExpression(type), new PlaceHolderColorExpression(type));
         } else {
             return new Pair<>(((LeftRightGuardExpression) currentSelection).getLeftExpression(),
                 ((LeftRightGuardExpression) currentSelection).getRightExpression());
@@ -589,7 +598,7 @@ public class ColoredTransitionGuardPanel  extends JPanel {
         if (guard != null) {
             newProperty = guard.copy();
         }
-        ColorType ct = getColorType(newProperty);
+        ColorType ct = newProperty.getColorType();
         doColorTypeUndo = false;
         if (ct != null)
             colorTypeCombobox.setSelectedItem(ct);
@@ -602,16 +611,17 @@ public class ColoredTransitionGuardPanel  extends JPanel {
 
     private void addColor() {
         Expression newExpression;
-        if (colorCombobox.getColorType() instanceof ProductType) {
+        ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+        if (type instanceof ProductType) {
             Object selectedElement = colorCombobox.getColorTypeComboBoxesArray()[0].getSelectedItem();
             if (selectedElement instanceof String) {
                 newExpression = new AllExpression(((ProductType)colorCombobox.getColorType()).getColorTypes().get(0));
             } else if (selectedElement instanceof Variable) {
-                newExpression = new VariableExpression((Variable)selectedElement);
+                newExpression = new VariableExpression((Variable)selectedElement, type);
             } else if (selectedElement instanceof PlaceHolderColorExpression) {
-                newExpression = new PlaceHolderColorExpression();
+                newExpression = new PlaceHolderColorExpression(type);
             } else {
-                newExpression = new UserOperatorExpression((dk.aau.cs.model.CPN.Color) selectedElement);
+                newExpression = new UserOperatorExpression((dk.aau.cs.model.CPN.Color) selectedElement, type);
             }
         } else {
             ColorExpression expr;
@@ -622,7 +632,7 @@ public class ColoredTransitionGuardPanel  extends JPanel {
             } else if(selectedElement instanceof Variable) {
                 expr = new VariableExpression((Variable) selectedElement);
             } else if (selectedElement instanceof PlaceHolderColorExpression) {
-                expr = new PlaceHolderColorExpression();
+                expr = new PlaceHolderColorExpression(type);
             } else {
                 expr = new UserOperatorExpression((dk.aau.cs.model.CPN.Color) selectedElement);
             }
@@ -714,6 +724,7 @@ public class ColoredTransitionGuardPanel  extends JPanel {
         currentSelection = position;
 
         updateEnabledButtons();
+        updateColorTypeSelection();
         updateColorSelection();
     }
 
@@ -732,7 +743,18 @@ public class ColoredTransitionGuardPanel  extends JPanel {
         currentSelection = position;
 
         updateEnabledButtons();
+        updateColorTypeSelection();
         updateColorSelection();
+    }
+
+    private void updateColorTypeSelection() {
+        doColorTypeUndo = false;
+        if (currentSelection.getObject() instanceof ColorExpression) {
+            colorTypeCombobox.setSelectedItem(((ColorExpression)currentSelection.getObject()).getColorType());
+        } else if (currentSelection.getObject() instanceof LeftRightGuardExpression) {
+            colorTypeCombobox.setSelectedItem(((GuardExpression)currentSelection.getObject()).getColorType());
+        }
+        doColorTypeUndo = true;
     }
 
     private void updateColorSelection() {
@@ -754,50 +776,6 @@ public class ColoredTransitionGuardPanel  extends JPanel {
         updatingColorSelection = false;
     }
 
-    private ColorType getColorType(Expression property) {
-        List<Expression> children = getPropertyChildren(property.getChildren());
-        ColorType colorType = getColorType(children);
-        if (colorType != null) return colorType;
-
-        // Checks string positions if the above fails to find a color
-        return getColorType(getChildrenExpressions(property.getChildren()));
-    }
-
-    private ColorType getColorType(List<Expression> children) {
-        List<ColorType> colorTypes = context.network().colorTypes();
-        List<ColorType> types = new ArrayList<>();
-        for (Expression child : children) {
-            if (child instanceof ColorExpression) {
-                types.add(((ColorExpression) child).getColorType(colorTypes));
-            } else if (child instanceof GuardExpression) {
-                return getColorType(getChildrenExpressions(child.getChildren()));
-            }
-        }
-        if (types.size() > 0) return types.get(0);
-        return null;
-    }
-
-    private List<Expression> getChildrenExpressions(ExprStringPosition[] childrenPosition) {
-        List<Expression> children = new ArrayList<>();
-        for (ExprStringPosition child : childrenPosition) {
-            children.add(child.getObject());
-        }
-        return children;
-    }
-
-    private List<Expression> getPropertyChildren(ExprStringPosition[] children) {
-        List<Expression> possibleExpressions = new ArrayList<>();
-        for (ExprStringPosition child : children) {
-            if (child.getObject().getChildren().length > 0) {
-                possibleExpressions.addAll(getPropertyChildren(child.getObject().getChildren()));
-            }
-            if (currentSelection != null && child.getEnd() >= 0 && child.getEnd() < currentSelection.getStart()) {
-                possibleExpressions.add(child.getObject());
-            }
-        }
-        return possibleExpressions;
-    }
-
     private void addColorTypesToCombobox(List<ColorType> types) {
         colorTypeCombobox.removeAllItems();
         for (ColorType type : types) {
@@ -812,7 +790,8 @@ public class ColoredTransitionGuardPanel  extends JPanel {
                 replacement = new PlaceHolderGuardExpression();
             }
             else if (currentSelection.getObject() instanceof ColorExpression) {
-                replacement = new PlaceHolderColorExpression();
+                ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+                replacement = new PlaceHolderColorExpression(type);
             }
             if (replacement != null) {
                 UndoableEdit edit = new ExpressionConstructionEdit(currentSelection.getObject(), replacement);
@@ -878,15 +857,14 @@ public class ColoredTransitionGuardPanel  extends JPanel {
     }
 
     public void onOK(pipe.gui.petrinet.undo.UndoManager undoManager) {
+        Command cmd;
         if (newProperty instanceof PlaceHolderGuardExpression) {
-            Command cmd = new SetTransitionExpressionCommand(transition, transition.getGuardExpression(), null);
-            cmd.redo();
-            undoManager.addEdit(cmd);
+            cmd = new SetTransitionExpressionCommand(transition, transition.getGuardExpression(), null);
         } else {
-            Command cmd = new SetTransitionExpressionCommand(transition, transition.getGuardExpression(), newProperty);
-            cmd.redo();
-            undoManager.addEdit(cmd);
+            cmd = new SetTransitionExpressionCommand(transition, transition.getGuardExpression(), newProperty);
         }
+        cmd.redo();
+        undoManager.addEdit(cmd);
     }
 
     private void replaceAndAddToUndo(Expression currentSelection, Expression newExpression){
@@ -907,7 +885,7 @@ public class ColoredTransitionGuardPanel  extends JPanel {
 
     private void updateExpression() {
         ColorType ct = colorTypeCombobox.getItemAt(colorTypeCombobox.getSelectedIndex());
-        if (ct == getColorType(newProperty)) return;
+        if (ct == newProperty.getColorType()) return;
 
         Expression oldProperty = currentSelection.getObject();
         if (doColorTypeUndo) {
@@ -938,9 +916,10 @@ public class ColoredTransitionGuardPanel  extends JPanel {
             if (child.getObject() instanceof ColorExpression) {
                 Expression expr;
                 if (ct instanceof ProductType) {
-                    expr = new TupleExpression(createPlaceholderVectors(ct.size()));
+                    expr = new TupleExpression(createPlaceholderVectors(ct.size()), ct);
                 } else {
-                    expr = new PlaceHolderColorExpression();
+                    ColorType type = (ColorType) colorTypeCombobox.getSelectedItem();
+                    expr = new PlaceHolderColorExpression(type);
                 }
                 replaceProperty = replaceProperty.replace(child.getObject(), expr);
             } else if (parent instanceof GuardExpression && child.getObject() instanceof LeftRightGuardExpression) {
@@ -948,6 +927,15 @@ public class ColoredTransitionGuardPanel  extends JPanel {
             }
         }
         return replaceProperty;
+    }
+
+    private ColorType getColorType(Expression expr) {
+        if (expr instanceof ColorExpression) {
+            return ((ColorExpression) expr).getColorType();
+        } else if (expr instanceof GuardExpression) {
+            return ((GuardExpression) expr).getColorType();
+        }
+        return null;
     }
 
     // /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added a color type variable, that remembers the color type of each part of the expression in the guards. 
This means when selecting part of an expression, the color type should be updated according to this selection to avoid invalid expressions.

Solves https://bugs.launchpad.net/tapaal/+bug/1986788.