### PR TITLE
Removes color exception on non-colored nets

### DIFF
--- a/src/main/java/dk/aau/cs/io/TapnXmlLoader.java
+++ b/src/main/java/dk/aau/cs/io/TapnXmlLoader.java
@@ -162,8 +162,9 @@ public class TapnXmlLoader {
         }
 		parseSharedPlaces(doc, network, constants);
 		parseSharedTransitions(doc, network);
-		
-		Collection<Template> templates = parseTemplates(doc, network, constants);
+        parseFeature(doc, network);
+
+        Collection<Template> templates = parseTemplates(doc, network, constants);
 		LoadedQueries loadedQueries = new TAPNQueryLoader(doc, network).parseQueries();
 
 		if (loadedQueries != null) {
@@ -172,7 +173,6 @@ public class TapnXmlLoader {
             }
         }
 		network.buildConstraints();
-		parseFeature(doc, network);
         network.setDefaultBound(3); // Ignores k-bounds in .tapn files
 
         if (hasFeatureTag) {
@@ -559,7 +559,9 @@ public class TapnXmlLoader {
 		}else{
 		    p = new LocalTimedPlace(nameInput, TimeInvariant.parse(invariant, constants), parsePlaceColorType(place));
 		    tapn.add(p);
-		    addColoredDependencies(p,place, network, constants);
+		    if (lens == null || lens.isColored()) {
+                addColoredDependencies(p, place, network, constants);
+            }
 
 		}
 		nameGenerator.updateIndicesForAllModels(nameInput);


### PR DESCRIPTION
When changing the net features, a non-colored net will not produce exceptions related to colored properties.

How to reproduce the problem:

- Open the token-ring net
- Change the net to non-colored
- Change the net to timed

The exception would appear, complaining that there is no color called process0 defined in the net