### PR TITLE
Select succ pred 1986938

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AndExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AndExpression.java
@@ -102,9 +102,6 @@ public class AndExpression extends GuardExpression {
         children[1] = pos;
 
         return children;
-
-
-
     }
 
     @Override

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AndExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AndExpression.java
@@ -102,6 +102,9 @@ public class AndExpression extends GuardExpression {
         children[1] = pos;
 
         return children;
+
+
+
     }
 
     @Override

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/NotExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/NotExpression.java
@@ -76,7 +76,7 @@ public class NotExpression extends GuardExpression {
     @Override
     public ExprStringPosition[] getChildren() {
         int start = 2;
-        int end = start + expr.toString().length()-1;
+        int end = start + expr.toString().length();
         ExprStringPosition pos = new ExprStringPosition(start, end, expr);
         return new ExprStringPosition[]{pos};
     }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/PredecessorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/PredecessorExpression.java
@@ -95,8 +95,7 @@ public class PredecessorExpression extends ColorExpression {
 
     @Override
     public ExprStringPosition[] getChildren() {
-
-        ExprStringPosition pos = new ExprStringPosition(0, color.toString().length() - 2, color);
+        ExprStringPosition pos = new ExprStringPosition(0, color.toString().length(), color);
         return new ExprStringPosition[]{pos};
     }
 

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/SuccessorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/SuccessorExpression.java
@@ -94,8 +94,7 @@ public class SuccessorExpression extends ColorExpression {
 
     @Override
     public ExprStringPosition[] getChildren() {
-
-        ExprStringPosition pos = new ExprStringPosition(0, color.toString().length() - 2 , color);
+        ExprStringPosition pos = new ExprStringPosition(0, color.toString().length(), color);
         return new ExprStringPosition[]{pos};
     }
 

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -691,10 +691,7 @@ public class ColoredTransitionGuardPanel  extends JPanel {
             succButton.setEnabled(false);
             predButton.setEnabled(false);
             colorCombobox.setEnabled(false);
-            colorTypeCombobox.setEnabled(
-                currentSelection.getObject() instanceof LeftRightGuardExpression ||
-                currentSelection.getObject() instanceof PlaceHolderGuardExpression
-            );
+            colorTypeCombobox.setEnabled(true);
         }
         if (colorTypeCombobox.getItemAt(colorTypeCombobox.getSelectedIndex()) instanceof ProductType) {
             greaterThanButton.setEnabled(false);
@@ -901,23 +898,14 @@ public class ColoredTransitionGuardPanel  extends JPanel {
 
     private Expression getTypeReplacement(ColorType ct) {
         Expression replacement = newProperty.copy();
-        replacement = findCurrentProperty(replacement, replacement);
-        if (replacement != null) {
+        if (replacement.indexOf(replacement).getStart() == currentSelection.getStart() && replacement.indexOf(replacement).getEnd() == currentSelection.getEnd()) {
             return updateChildren(replacement, ct, replacement, replacement.getChildren());
         }
-        return null;
-    }
 
-    private Expression findCurrentProperty(Expression original, Expression replacement) {
         for (ExprStringPosition exprStr : replacement.getChildren()) {
-            if (exprStr.getObject() instanceof LeftRightGuardExpression) {
-                if (original.indexOf(exprStr.getObject()).getStart() == currentSelection.getStart() &&
-                    original.indexOf(exprStr.getObject()).getEnd() == currentSelection.getEnd()) {
-                    return exprStr.getObject().copy();
-                }
-            } else {
-                Expression expr = findCurrentProperty(original, exprStr.getObject());
-                if (expr != null) return expr;
+            if (exprStr.getStart() == currentSelection.getStart() && exprStr.getEnd() == currentSelection.getEnd()) {
+                replacement = exprStr.getObject().copy();
+                return updateChildren(replacement, ct, replacement, replacement.getChildren());
             }
         }
         return null;

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -691,7 +691,10 @@ public class ColoredTransitionGuardPanel  extends JPanel {
             succButton.setEnabled(false);
             predButton.setEnabled(false);
             colorCombobox.setEnabled(false);
-            colorTypeCombobox.setEnabled(true);
+            colorTypeCombobox.setEnabled(
+                currentSelection.getObject() instanceof LeftRightGuardExpression ||
+                currentSelection.getObject() instanceof PlaceHolderGuardExpression
+            );
         }
         if (colorTypeCombobox.getItemAt(colorTypeCombobox.getSelectedIndex()) instanceof ProductType) {
             greaterThanButton.setEnabled(false);
@@ -898,14 +901,23 @@ public class ColoredTransitionGuardPanel  extends JPanel {
 
     private Expression getTypeReplacement(ColorType ct) {
         Expression replacement = newProperty.copy();
-        if (replacement.indexOf(replacement).getStart() == currentSelection.getStart() && replacement.indexOf(replacement).getEnd() == currentSelection.getEnd()) {
+        replacement = findCurrentProperty(replacement, replacement);
+        if (replacement != null) {
             return updateChildren(replacement, ct, replacement, replacement.getChildren());
         }
+        return null;
+    }
 
+    private Expression findCurrentProperty(Expression original, Expression replacement) {
         for (ExprStringPosition exprStr : replacement.getChildren()) {
-            if (exprStr.getStart() == currentSelection.getStart() && exprStr.getEnd() == currentSelection.getEnd()) {
-                replacement = exprStr.getObject().copy();
-                return updateChildren(replacement, ct, replacement, replacement.getChildren());
+            if (exprStr.getObject() instanceof LeftRightGuardExpression) {
+                if (original.indexOf(exprStr.getObject()).getStart() == currentSelection.getStart() &&
+                    original.indexOf(exprStr.getObject()).getEnd() == currentSelection.getEnd()) {
+                    return exprStr.getObject().copy();
+                }
+            } else {
+                Expression expr = findCurrentProperty(original, exprStr.getObject());
+                if (expr != null) return expr;
             }
         }
         return null;

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -885,7 +885,7 @@ public class ColoredTransitionGuardPanel  extends JPanel {
 
     private void updateExpression() {
         ColorType ct = colorTypeCombobox.getItemAt(colorTypeCombobox.getSelectedIndex());
-        if (ct == newProperty.getColorType()) return;
+        if (ct == getColorType(currentSelection.getObject())) return;
 
         Expression oldProperty = currentSelection.getObject();
         if (doColorTypeUndo) {


### PR DESCRIPTION
Fixes the issue where you can't select an expression with only one letter in the name if it contains predecessors or sucessors.

Solves https://bugs.launchpad.net/tapaal/+bug/1986938.