### PR TITLE
color-type-change-fix-1987058

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AndExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AndExpression.java
@@ -102,9 +102,6 @@ public class AndExpression extends GuardExpression {
         children[1] = pos;
 
         return children;
-
-
-
     }
 
     @Override

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -691,7 +691,10 @@ public class ColoredTransitionGuardPanel  extends JPanel {
             succButton.setEnabled(false);
             predButton.setEnabled(false);
             colorCombobox.setEnabled(false);
-            colorTypeCombobox.setEnabled(true);
+            colorTypeCombobox.setEnabled(
+                currentSelection.getObject() instanceof LeftRightGuardExpression ||
+                currentSelection.getObject() instanceof PlaceHolderGuardExpression
+            );
         }
         if (colorTypeCombobox.getItemAt(colorTypeCombobox.getSelectedIndex()) instanceof ProductType) {
             greaterThanButton.setEnabled(false);
@@ -898,14 +901,23 @@ public class ColoredTransitionGuardPanel  extends JPanel {
 
     private Expression getTypeReplacement(ColorType ct) {
         Expression replacement = newProperty.copy();
-        if (replacement.indexOf(replacement).getStart() == currentSelection.getStart() && replacement.indexOf(replacement).getEnd() == currentSelection.getEnd()) {
+        replacement = findCurrentProperty(replacement, replacement);
+        if (replacement != null) {
             return updateChildren(replacement, ct, replacement, replacement.getChildren());
         }
+        return null;
+    }
 
+    private Expression findCurrentProperty(Expression original, Expression replacement) {
         for (ExprStringPosition exprStr : replacement.getChildren()) {
-            if (exprStr.getStart() == currentSelection.getStart() && exprStr.getEnd() == currentSelection.getEnd()) {
-                replacement = exprStr.getObject().copy();
-                return updateChildren(replacement, ct, replacement, replacement.getChildren());
+            if (exprStr.getObject() instanceof LeftRightGuardExpression) {
+                if (original.indexOf(exprStr.getObject()).getStart() == currentSelection.getStart() &&
+                    original.indexOf(exprStr.getObject()).getEnd() == currentSelection.getEnd()) {
+                    return exprStr.getObject().copy();
+                }
+            } else {
+                Expression expr = findCurrentProperty(original, exprStr.getObject());
+                if (expr != null) return expr;
             }
         }
         return null;

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -870,11 +870,13 @@ public class ColoredTransitionGuardPanel  extends JPanel {
         undoManager.addEdit(cmd);
     }
 
-    private void replaceAndAddToUndo(Expression currentSelection, Expression newExpression){
-        UndoableEdit edit = new ExpressionConstructionEdit(currentSelection, newExpression);
-        newProperty = newProperty.replace(currentSelection, newExpression);
-        updateSelection(newExpression);
-        undoSupport.postEdit(edit);
+    private void replaceAndAddToUndo(Expression currentSelection, Expression newExpression) {
+        if (currentSelection != null && newExpression != null) {
+            UndoableEdit edit = new ExpressionConstructionEdit(currentSelection, newExpression);
+            newProperty = newProperty.replace(currentSelection, newExpression);
+            updateSelection(newExpression);
+            undoSupport.postEdit(edit);
+        }
     }
 
     private void updateColorType() {
@@ -909,6 +911,10 @@ public class ColoredTransitionGuardPanel  extends JPanel {
     }
 
     private Expression findCurrentProperty(Expression original, Expression replacement) {
+        if (original == replacement && replacement instanceof LeftRightGuardExpression) {
+            return replacement;
+        }
+
         for (ExprStringPosition exprStr : replacement.getChildren()) {
             if (exprStr.getObject() instanceof LeftRightGuardExpression) {
                 if (original.indexOf(exprStr.getObject()).getStart() == currentSelection.getStart() &&


### PR DESCRIPTION
Considers logic expressions when updating the color type of an expression

Solves https://bugs.launchpad.net/tapaal/+bug/1987058.
In addition, disabled the option to change the color type while selecting a log expression (AND, NOT, OR)