### PR TITLE
selection-behaviour-1987059

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -704,8 +704,8 @@ public class ColoredTransitionGuardPanel  extends JPanel {
     }
 
     private void checkSelectionComparison() {
-        if (currentSelection != null && (currentSelection.getObject() instanceof GreaterThanEqExpression || currentSelection.getObject() instanceof GreaterThanExpression ||
-            currentSelection.getObject() instanceof LessThanEqExpression || currentSelection.getObject() instanceof LessThanExpression)) {
+        if (currentSelection != null && !(newProperty instanceof PlaceHolderGuardExpression) &&
+            !(currentSelection.getObject() instanceof EqualityExpression || currentSelection.getObject() instanceof InequalityExpression)) {
             deleteSelection();
         }
     }

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -705,7 +705,8 @@ public class ColoredTransitionGuardPanel  extends JPanel {
 
     private void checkSelectionComparison() {
         if (currentSelection != null && !(newProperty instanceof PlaceHolderGuardExpression) &&
-            !(currentSelection.getObject() instanceof EqualityExpression || currentSelection.getObject() instanceof InequalityExpression)) {
+            (currentSelection.getObject() instanceof GreaterThanEqExpression || currentSelection.getObject() instanceof GreaterThanExpression ||
+                currentSelection.getObject() instanceof LessThanEqExpression || currentSelection.getObject() instanceof LessThanExpression)) {
             deleteSelection();
         }
     }

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -714,12 +714,12 @@ public class ColoredTransitionGuardPanel  extends JPanel {
         exprField.setText(newProperty.toString());
 
         ExprStringPosition position;
-        if (newProperty.containsPlaceHolder()) {
-            Expression ge = newProperty.findFirstPlaceHolder();
-            position = newProperty.indexOf(ge);
+        if (newSelection instanceof PredecessorExpression || newSelection instanceof SuccessorExpression) {
+            position = newProperty.indexOf(((ColorExpression) newSelection).getBottomColorExpression());
         } else {
             position = newProperty.indexOf(newSelection);
         }
+
         exprField.select(position.getStart(), position.getEnd());
         currentSelection = position;
 


### PR DESCRIPTION
Selection does not jump to the first placeholder anymore.

When a succ/pred is added, the bottom color expression is selected. This means that the succ/pred is not removed when changing the color.

Solves https://bugs.launchpad.net/tapaal/+bug/1987059.