### PR TITLE
arc-dialog-freeze-1987061

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredArcGuardPanel.java
@@ -952,7 +952,7 @@ public abstract class ColoredArcGuardPanel extends JPanel {
             colorExpressionComboBoxPanel.updateSelection(colorExpression);
         } else if (current instanceof ColorExpression) {
             colorExpressionComboBoxPanel.updateSelection(((ColorExpression) current).getBottomColorExpression());
-        } else if (current instanceof ArcExpression) {
+        } else if (current instanceof ArcExpression && !(current instanceof PlaceHolderArcExpression)) {
             updateNumberExpressionsPanel(getSpecificChildOfProperty(1, current));
         }
         updatingSelection = false;


### PR DESCRIPTION
Added check to avoid infinite loop when resetting an expression in the arc dialog.

Solves https://bugs.launchpad.net/tapaal/+bug/1987061.