### PR TITLE
Remove dot from dialogs 1987288

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColorComboboxPanel.java
@@ -186,8 +186,10 @@ public abstract class ColorComboboxPanel extends JPanel {
     @Override
     public void setEnabled(boolean enabled){
         colorcomboBoxPanel.setEnabled(enabled);
-        for (var combobox : colorTypeComboBoxesArray) {
-            combobox.setEnabled(enabled);
+        if (colorTypeComboBoxesArray != null) {
+            for (var combobox : colorTypeComboBoxesArray) {
+                combobox.setEnabled(enabled);
+            }
         }
     }
 }

--- a/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/ColoredTransitionGuardPanel.java
@@ -600,10 +600,12 @@ public class ColoredTransitionGuardPanel  extends JPanel {
         }
         ColorType ct = newProperty.getColorType();
         doColorTypeUndo = false;
-        if (ct != null)
-            colorTypeCombobox.setSelectedItem(ct);
-        else
-            colorTypeCombobox.setSelectedIndex(0);
+        if (colorTypeCombobox.getItemCount() > 0) {
+            if (ct != null)
+                colorTypeCombobox.setSelectedItem(ct);
+            else
+                colorTypeCombobox.setSelectedIndex(0);
+        }
         doColorTypeUndo = true;
         updateSelection(newProperty);
         colorTypeCombobox.setEnabled(newProperty instanceof PlaceHolderGuardExpression);
@@ -784,6 +786,7 @@ public class ColoredTransitionGuardPanel  extends JPanel {
         for (ColorType type : types) {
             colorTypeCombobox.addItem(type);
         }
+        colorTypeCombobox.removeItem(ColorType.COLORTYPE_DOT);
     }
 
     private void deleteSelection() {
@@ -954,6 +957,10 @@ public class ColoredTransitionGuardPanel  extends JPanel {
             return ((GuardExpression) expr).getColorType();
         }
         return null;
+    }
+
+    public boolean showGuardPanel() {
+        return colorTypeCombobox.getItemCount() > 0;
     }
 
     // /////////////////////////////////////////////////////////////////////

--- a/src/main/java/net/tapaal/gui/petrinet/editor/VariablesDialogPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/VariablesDialogPanel.java
@@ -49,9 +49,7 @@ public class VariablesDialogPanel extends JPanel {
         this.network = network;
         this.listModel = listModel;
         initComponents();
-        if (nameTextField != null) {
-            nameTextField.setText(oldName);
-        }
+        nameTextField.setText(oldName);
         this.undoManager = undoManager;
     }
 
@@ -62,14 +60,12 @@ public class VariablesDialogPanel extends JPanel {
         this.network = network;
         this.listModel = listModel;
         initComponents();
-        if (nameTextField != null) {
-            nameTextField.setText(oldName);
-        }
+        nameTextField.setText(oldName);
         this.undoManager = undoManager;
     }
 
     public void showDialog() {
-        if (scrollPane == null || okButton == null) return;
+        if (colorTypeComboBox.getItemCount() <= 0) return;
         String panelHeader = variable != null? "Edit Variable" : "Create Variable";
 
         dialog = new EscapableDialog(TAPAALGUI.getApp(),
@@ -82,40 +78,34 @@ public class VariablesDialogPanel extends JPanel {
         dialog.setVisible(true);
     }
 
-    private void initComponents() throws IOException {
+    private void initComponents() {
         container = new JPanel();
         buttonContainer = new JPanel();
         container.setLayout(new GridBagLayout());
         size = new Dimension(330, 30);
 
-        try {
-            createCancelButton();
-            createColorTypeLabel();
-            createColorTypesComboBox();
-            createNameLabel();
-            createNameTextField();
-            createOKButton();
 
-            okButton.addActionListener(e -> onOK());
+        createCancelButton();
+        createColorTypeLabel();
+        createColorTypesComboBox();
+        createNameLabel();
+        createNameTextField();
+        createOKButton();
 
-            cancelButton.addActionListener(e -> exit());
+        okButton.addActionListener(e -> onOK());
+        cancelButton.addActionListener(e -> exit());
 
-            GridBagConstraints gbc = new GridBagConstraints();
-            gbc.insets = new Insets(0, 8, 5, 8);
-            gbc.gridx = 1;
-            gbc.gridy = 2;
-            gbc.gridwidth = 1;
-            gbc.anchor = GridBagConstraints.EAST;
-            container.add(buttonContainer, gbc);
-            scrollPane = new JScrollPane();
-            scrollPane.setViewportView(container);
-            scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-            scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
-        } catch (IOException e) {
-            throw e;
-        } catch (Exception e) {
-            JOptionPane.showMessageDialog(this, e.getMessage(), "", JOptionPane.INFORMATION_MESSAGE);
-        }
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(0, 8, 5, 8);
+        gbc.gridx = 1;
+        gbc.gridy = 2;
+        gbc.gridwidth = 1;
+        gbc.anchor = GridBagConstraints.EAST;
+        container.add(buttonContainer, gbc);
+        scrollPane = new JScrollPane();
+        scrollPane.setViewportView(container);
+        scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
     }
 
     private void createNameTextField() {
@@ -177,7 +167,7 @@ public class VariablesDialogPanel extends JPanel {
         container.add(colorTypeLabel,gbc);
     }
 
-    private void createColorTypesComboBox() throws Exception {
+    private void createColorTypesComboBox() {
         colorTypes = new ArrayList<>();
         colorTypes = network.colorTypes();
 
@@ -196,7 +186,8 @@ public class VariablesDialogPanel extends JPanel {
         }
         colorTypeComboBox.removeItem(ColorType.COLORTYPE_DOT);
         if (colorTypeComboBox.getItemCount() <= 0) {
-            throw new Exception("No valid color types available for variables");
+            JOptionPane.showMessageDialog(this, "No valid color types available for variables", "", JOptionPane.INFORMATION_MESSAGE);
+            return;
         }
         colorTypeComboBox.setSelectedIndex(variableIndex);
 

--- a/src/main/java/net/tapaal/gui/petrinet/editor/VariablesDialogPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/VariablesDialogPanel.java
@@ -49,7 +49,9 @@ public class VariablesDialogPanel extends JPanel {
         this.network = network;
         this.listModel = listModel;
         initComponents();
-        nameTextField.setText(oldName);
+        if (nameTextField != null) {
+            nameTextField.setText(oldName);
+        }
         this.undoManager = undoManager;
     }
 
@@ -60,11 +62,14 @@ public class VariablesDialogPanel extends JPanel {
         this.network = network;
         this.listModel = listModel;
         initComponents();
-        nameTextField.setText(oldName);
+        if (nameTextField != null) {
+            nameTextField.setText(oldName);
+        }
         this.undoManager = undoManager;
     }
 
     public void showDialog() {
+        if (scrollPane == null || okButton == null) return;
         String panelHeader = variable != null? "Edit Variable" : "Create Variable";
 
         dialog = new EscapableDialog(TAPAALGUI.getApp(),
@@ -83,28 +88,34 @@ public class VariablesDialogPanel extends JPanel {
         container.setLayout(new GridBagLayout());
         size = new Dimension(330, 30);
 
-        createCancelButton();
-        createColorTypeLabel();
-        createcolorTypesComboBox();
-        createNameLabel();
-        createNameTextField();
-        createOKButton();
+        try {
+            createCancelButton();
+            createColorTypeLabel();
+            createColorTypesComboBox();
+            createNameLabel();
+            createNameTextField();
+            createOKButton();
 
-        okButton.addActionListener(e -> onOK());
+            okButton.addActionListener(e -> onOK());
 
-        cancelButton.addActionListener(e -> exit());
+            cancelButton.addActionListener(e -> exit());
 
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.insets = new Insets(0, 8, 5, 8);
-        gbc.gridx = 1;
-        gbc.gridy = 2;
-        gbc.gridwidth = 1;
-        gbc.anchor = GridBagConstraints.EAST;
-        container.add(buttonContainer,gbc);
-        scrollPane = new JScrollPane();
-        scrollPane.setViewportView(container);
-        scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
-        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+            GridBagConstraints gbc = new GridBagConstraints();
+            gbc.insets = new Insets(0, 8, 5, 8);
+            gbc.gridx = 1;
+            gbc.gridy = 2;
+            gbc.gridwidth = 1;
+            gbc.anchor = GridBagConstraints.EAST;
+            container.add(buttonContainer, gbc);
+            scrollPane = new JScrollPane();
+            scrollPane.setViewportView(container);
+            scrollPane.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+            scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            JOptionPane.showMessageDialog(this, e.getMessage(), "", JOptionPane.INFORMATION_MESSAGE);
+        }
     }
 
     private void createNameTextField() {
@@ -166,8 +177,7 @@ public class VariablesDialogPanel extends JPanel {
         container.add(colorTypeLabel,gbc);
     }
 
-
-    private void createcolorTypesComboBox() {
+    private void createColorTypesComboBox() throws Exception {
         colorTypes = new ArrayList<>();
         colorTypes = network.colorTypes();
 
@@ -183,6 +193,10 @@ public class VariablesDialogPanel extends JPanel {
                     }
                 }
             }
+        }
+        colorTypeComboBox.removeItem(ColorType.COLORTYPE_DOT);
+        if (colorTypeComboBox.getItemCount() <= 0) {
+            throw new Exception("No valid color types available for variables");
         }
         colorTypeComboBox.setSelectedIndex(variableIndex);
 

--- a/src/main/java/net/tapaal/gui/petrinet/editor/VariablesDialogPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/VariablesDialogPanel.java
@@ -84,7 +84,6 @@ public class VariablesDialogPanel extends JPanel {
         container.setLayout(new GridBagLayout());
         size = new Dimension(330, 30);
 
-
         createCancelButton();
         createColorTypeLabel();
         createColorTypesComboBox();

--- a/src/main/java/pipe/gui/petrinet/editor/TAPNTransitionEditor.java
+++ b/src/main/java/pipe/gui/petrinet/editor/TAPNTransitionEditor.java
@@ -59,7 +59,7 @@ public class TAPNTransitionEditor extends JPanel {
 	    if(!transition.isTimed()) {
             urgentCheckBox.setVisible(false);
         }
-	    if(!transition.isColored()){
+	    if(!transition.isColored() || !coloredTransitionGuardPanel.showGuardPanel()){
 	        coloredTransitionGuardPanel.setVisible(false);
         }
     }


### PR DESCRIPTION
Removed dot color type from both the variable and transition dialogs.

Solves https://bugs.launchpad.net/tapaal/+bug/1987288.