### PR TITLE
Update tokens 1988664

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/Color.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Color.java
@@ -134,4 +134,11 @@ public class Color {
         }
         return new Color(colorType.copy(), id, colors);
     }
+
+    public Color getExprWithNewColorType(ColorType ct) {
+        if (colorType.getName().equals(ct.getName())) {
+            return new Color(ct, id, tuple, colorName);
+        }
+        return this;
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AddExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AddExpression.java
@@ -2,6 +2,7 @@ package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.Color;
 import dk.aau.cs.model.CPN.ColorMultiset;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprStringPosition;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
@@ -21,7 +22,6 @@ public class AddExpression extends ArcExpression {
         super(otherExpr);
         this.constituents = new Vector<>(otherExpr.constituents);
     }
-
 
     public Vector<ArcExpression> getAddExpression (){return constituents;}
 
@@ -52,6 +52,7 @@ public class AddExpression extends ArcExpression {
     public ArcExpression replace(Expression object1, Expression object2){
         return replace(object1,object2,false);
     }
+
     @Override
     public ArcExpression replace(Expression object1, Expression object2, boolean replaceAllInstances) {
         if (object1 == this && object2 instanceof ArcExpression) {
@@ -181,5 +182,13 @@ public class AddExpression extends ArcExpression {
             res.append(constituent.toString()).append("\n");
         }
         return res.toString();
+    }
+
+    public AddExpression getExprWithNewColorType(ColorType ct) {
+        Vector<ArcExpression> arcExpressions = new Vector<>();
+        for (ArcExpression expr : constituents) {
+            arcExpressions.add(expr.getExprWithNewColorType(ct));
+        }
+        return new AddExpression(arcExpressions);
     }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AllExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AllExpression.java
@@ -135,4 +135,12 @@ public class AllExpression extends ColorExpression {
     public Vector<ColorType> getColorTypes() {
         return new Vector<>(Collections.singletonList(sort));
     }
+
+    @Override
+    public ColorExpression getExprWithNewColorType(ColorType ct) {
+        if (sort.getName().equals(ct.getName())) {
+            return new AllExpression(ct);
+        }
+        return deepCopy();
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/ArcExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/ArcExpression.java
@@ -1,6 +1,7 @@
 package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.ColorMultiset;
+import dk.aau.cs.model.CPN.ColorType;
 
 public abstract class ArcExpression extends Expression {
 
@@ -34,4 +35,6 @@ public abstract class ArcExpression extends Expression {
     public abstract ColorMultiset eval(ExpressionContext context);
 
     public abstract Integer weight();
+
+    public abstract ArcExpression getExprWithNewColorType(ColorType ct);
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/ColorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/ColorExpression.java
@@ -60,4 +60,6 @@ public abstract class ColorExpression extends Expression {
     public int getIndex(){
         return index;
     }
+
+    public abstract ColorExpression getExprWithNewColorType(ColorType ct);
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/DotConstantExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/DotConstantExpression.java
@@ -99,4 +99,9 @@ public class DotConstantExpression extends UserOperatorExpression {
     public Vector<ColorType> getColorTypes() {
         return new Vector<>(Collections.singletonList(colorType));
     }
+
+    @Override
+    public ColorExpression getExprWithNewColorType(ColorType ct) {
+        return deepCopy();
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
@@ -176,4 +176,17 @@ public class NumberOfExpression extends ArcExpression {
     public void setNumber(int newNumber){
         number = newNumber;
     }
+
+    @Override
+    public ArcExpression getExprWithNewColorType(ColorType ct) {
+        Vector<ColorExpression> colorExpressions = new Vector<>();
+        ColorExpression colorExpression = color.get(0);
+
+        if (colorExpression.colorType == null || colorExpression.colorType.getName().equals(ct.getName())) {
+            colorExpressions.add(colorExpression.getExprWithNewColorType(ct));
+        } else {
+            colorExpressions.add(colorExpression);
+        }
+        return new NumberOfExpression(number, colorExpressions);
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderArcExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderArcExpression.java
@@ -2,6 +2,7 @@ package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.Color;
 import dk.aau.cs.model.CPN.ColorMultiset;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
 
@@ -72,5 +73,10 @@ public class PlaceHolderArcExpression extends ArcExpression implements PlaceHold
     @Override
     public String toString() {
         return "<->";
+    }
+
+    @Override
+    public ArcExpression getExprWithNewColorType(ColorType ct) {
+        return deepCopy();
     }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderColorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderColorExpression.java
@@ -106,4 +106,9 @@ public class PlaceHolderColorExpression extends ColorExpression implements Place
     public Vector<ColorType> getColorTypes() {
         return new Vector<>();
     }
+
+    @Override
+    public ColorExpression getExprWithNewColorType(ColorType ct) {
+        return deepCopy();
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/PredecessorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/PredecessorExpression.java
@@ -119,4 +119,8 @@ public class PredecessorExpression extends ColorExpression {
         return color.getColorTypes();
     }
 
+    @Override
+    public ColorExpression getExprWithNewColorType(ColorType ct) {
+        return new PredecessorExpression(color.getExprWithNewColorType(ct));
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/ScalarProductExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/ScalarProductExpression.java
@@ -2,6 +2,7 @@ package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.Color;
 import dk.aau.cs.model.CPN.ColorMultiset;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprStringPosition;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
@@ -110,5 +111,10 @@ public class ScalarProductExpression extends ArcExpression {
 
     public String toString() {
         return scalar.toString() + " * " + expr.toString();
+    }
+
+    @Override
+    public ArcExpression getExprWithNewColorType(ColorType ct) {
+        return new ScalarProductExpression(scalar, expr.getExprWithNewColorType(ct));
     }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/SubtractExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/SubtractExpression.java
@@ -2,6 +2,7 @@ package dk.aau.cs.model.CPN.Expressions;
 
 import dk.aau.cs.model.CPN.Color;
 import dk.aau.cs.model.CPN.ColorMultiset;
+import dk.aau.cs.model.CPN.ColorType;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprStringPosition;
 import dk.aau.cs.model.CPN.ExpressionSupport.ExprValues;
 import dk.aau.cs.model.CPN.Variable;
@@ -135,4 +136,8 @@ public class SubtractExpression extends ArcExpression {
         return false;
     }
 
+    @Override
+    public ArcExpression getExprWithNewColorType(ColorType ct) {
+        return new SubtractExpression(left.getExprWithNewColorType(ct), right.getExprWithNewColorType(ct));
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/SuccessorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/SuccessorExpression.java
@@ -117,4 +117,9 @@ public class SuccessorExpression extends ColorExpression {
     public Vector<ColorType> getColorTypes() {
         return color.getColorTypes();
     }
+
+    @Override
+    public ColorExpression getExprWithNewColorType(ColorType ct) {
+        return new SuccessorExpression(color.getExprWithNewColorType(ct));
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/TupleExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/TupleExpression.java
@@ -254,4 +254,16 @@ public class TupleExpression extends ColorExpression {
         }
         return constituentColorTypes;
     }
+
+    public TupleExpression getExprWithNewColorType(ColorType ct) {
+        Vector<ColorExpression> colorExpressions = new Vector<>();
+        for (ColorExpression colorExpression : colors) {
+            if (colorExpression.colorType.getName().equals(ct.getName())) {
+                colorExpressions.add(colorExpression.getExprWithNewColorType(ct));
+            } else {
+                colorExpressions.add(colorExpression);
+            }
+        }
+        return new TupleExpression(colorExpressions, ct);
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/UserOperatorExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/UserOperatorExpression.java
@@ -135,5 +135,8 @@ public class UserOperatorExpression extends ColorExpression {
         return new Vector<>(Collections.singletonList(userOperator.getColorType()));
     }
 
-
+    @Override
+    public ColorExpression getExprWithNewColorType(ColorType ct) {
+        return new UserOperatorExpression(userOperator.getExprWithNewColorType(ct));
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/VariableExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/VariableExpression.java
@@ -175,4 +175,8 @@ public class VariableExpression extends ColorExpression {
         return new Vector<>(Collections.singletonList(variable.getColorType()));
     }
 
+    @Override
+    public ColorExpression getExprWithNewColorType(ColorType ct) {
+        return new VariableExpression(variable.getExprWithNewColorType(ct));
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Variable.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Variable.java
@@ -31,4 +31,10 @@ public class Variable {
         return "<html>" + name + "<b> in </b>" + colorType.getName() + "</html>";
     }
 
+    public Variable getExprWithNewColorType(ColorType ct) {
+        if (colorType.getName().equals(ct.getName())) {
+            return new Variable(name, id, ct);
+        }
+        return this;
+    }
 }

--- a/src/main/java/dk/aau/cs/model/tapn/TimedPlace.java
+++ b/src/main/java/dk/aau/cs/model/tapn/TimedPlace.java
@@ -272,4 +272,7 @@ public abstract class TimedPlace {
         return tokensAsExpression;
     }
 
+    public ArcExpression getExprWithNewColorType(ColorType colorType) {
+	    return tokensAsExpression.getExprWithNewColorType(colorType);
+    }
 }

--- a/src/main/java/dk/aau/cs/model/tapn/TimedPlace.java
+++ b/src/main/java/dk/aau/cs/model/tapn/TimedPlace.java
@@ -282,6 +282,9 @@ public abstract class TimedPlace {
     }
 
     public ArcExpression getExprWithNewColorType(ColorType colorType) {
-	    return tokensAsExpression.getExprWithNewColorType(colorType);
+	    if (tokensAsExpression != null)
+	        return tokensAsExpression.getExprWithNewColorType(colorType);
+	    else
+	        return tokensAsExpression;
     }
 }

--- a/src/main/java/net/tapaal/gui/petrinet/undo/Colored/ColoredPlaceMarkingEditCommand.java
+++ b/src/main/java/net/tapaal/gui/petrinet/undo/Colored/ColoredPlaceMarkingEditCommand.java
@@ -48,7 +48,6 @@ public class ColoredPlaceMarkingEditCommand extends Command {
 
     @Override
     public void undo() {
-
         for (TimedToken token : newTokenList) {
             context.activeModel().marking().remove(token);
         }


### PR DESCRIPTION
When a color type is updated with a new color, the tokens that contain that color type is also updated.
Fixes problem with the token count not being updated.

Solves https://bugs.launchpad.net/tapaal/+bug/1988664.

OBS: The token count for product colors are not shown correctly, as this depends on PR #42 being merged.