### PR TITLE
Labels moving 1988737

### DIFF
--- a/src/main/java/dk/aau/cs/io/TapnXmlLoader.java
+++ b/src/main/java/dk/aau/cs/io/TapnXmlLoader.java
@@ -968,8 +968,8 @@ public class TapnXmlLoader {
 						String arcTempType = element.getAttribute("arcPointType");
 						double arcPointX = Double.parseDouble(arcTempX);
 						double arcPointY = Double.parseDouble(arcTempY);
-						arcPointX += Constants.ARC_CONTROL_POINT_CONSTANT + 1;
-						arcPointY += Constants.ARC_CONTROL_POINT_CONSTANT + 1;
+						//arcPointX += Constants.ARC_CONTROL_POINT_CONSTANT + 1;
+						//arcPointY += Constants.ARC_CONTROL_POINT_CONSTANT + 1;
 						boolean arcPointType = Boolean.parseBoolean(arcTempType);
 						tempArc.getArcPath().addPoint(arcPointX, arcPointY,	arcPointType);
 					}

--- a/src/main/resources/Example nets/ERK.tapn
+++ b/src/main/resources/Example nets/ERK.tapn
@@ -108,9 +108,9 @@
       <arcpath arcPointType="false" id="1" xCoord="469" yCoord="254"/>
     </arc>
     <arc id="A37" inscription="1" nameOffsetX="0" nameOffsetY="0" source="r5" target="Raf1Star" type="normal" weight="1">
-      <arcpath arcPointType="false" id="0" xCoord="459" yCoord="525"/>
-      <arcpath arcPointType="false" id="1" xCoord="395" yCoord="529"/>
-      <arcpath arcPointType="false" id="2" xCoord="390" yCoord="104"/>
+      <arcpath arcPointType="false" id="0" xCoord="460" yCoord="520"/>
+      <arcpath arcPointType="false" id="1" xCoord="390" yCoord="520"/>
+      <arcpath arcPointType="false" id="2" xCoord="390" yCoord="105"/>
     </arc>
     <arc id="A38" inscription="1" nameOffsetX="0" nameOffsetY="0" source="r10" target="RP" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="704" yCoord="424"/>
@@ -130,8 +130,8 @@
     </arc>
     <arc id="A43" inscription="1" nameOffsetX="0" nameOffsetY="0" source="r8" target="MEKPP" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="219" yCoord="330"/>
-      <arcpath arcPointType="false" id="1" xCoord="136" yCoord="334"/>
-      <arcpath arcPointType="false" id="2" xCoord="135" yCoord="600"/>
+      <arcpath arcPointType="false" id="1" xCoord="136" yCoord="330"/>
+      <arcpath arcPointType="false" id="2" xCoord="136" yCoord="600"/>
     </arc>
     <arc id="A44" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="MEKPP_ERK" target="r8" type="timed" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="225" yCoord="405"/>
@@ -147,22 +147,22 @@
     </arc>
     <arc id="A33" inscription="1" nameOffsetX="0" nameOffsetY="0" source="r11" target="RP" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="679" yCoord="240"/>
-      <arcpath arcPointType="false" id="1" xCoord="771" yCoord="242"/>
+      <arcpath arcPointType="false" id="1" xCoord="765" yCoord="240"/>
       <arcpath arcPointType="false" id="2" xCoord="765" yCoord="510"/>
     </arc>
     <arc id="A43" inscription="1" nameOffsetX="0" nameOffsetY="0" source="r11" target="RKIP" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="675" yCoord="225"/>
-      <arcpath arcPointType="false" id="1" xCoord="680" yCoord="92"/>
+      <arcpath arcPointType="false" id="1" xCoord="675" yCoord="90"/>
       <arcpath arcPointType="false" id="2" xCoord="569" yCoord="90"/>
     </arc>
     <arc id="A34" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="ERKPP" target="r3" type="timed" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="237" yCoord="248"/>
-      <arcpath arcPointType="false" id="1" xCoord="365" yCoord="336"/>
+      <arcpath arcPointType="false" id="1" xCoord="365" yCoord="329"/>
       <arcpath arcPointType="false" id="2" xCoord="420" yCoord="329"/>
     </arc>
     <arc id="A44" inscription="1" nameOffsetX="0" nameOffsetY="0" source="r4" target="ERKPP" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="494" yCoord="324"/>
-      <arcpath arcPointType="false" id="1" xCoord="363" yCoord="246"/>
+      <arcpath arcPointType="false" id="1" xCoord="363" yCoord="240"/>
       <arcpath arcPointType="false" id="2" xCoord="239" yCoord="240"/>
     </arc>
   </net>

--- a/src/main/resources/Example nets/alternating-bit-protocol-components.tapn
+++ b/src/main/resources/Example nets/alternating-bit-protocol-components.tapn
@@ -73,7 +73,7 @@
     </arc>
     <arc id="Ack_rec_1 to Sender_A" inscription="1" nameOffsetX="0" nameOffsetY="0" source="Ack_rec_1" target="Sender_A" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="165" yCoord="740"/>
-      <arcpath arcPointType="false" id="1" xCoord="146" yCoord="791"/>
+      <arcpath arcPointType="false" id="1" xCoord="165" yCoord="791"/>
       <arcpath arcPointType="false" id="2" xCoord="86" yCoord="791"/>
       <arcpath arcPointType="false" id="3" xCoord="86" yCoord="56"/>
       <arcpath arcPointType="false" id="4" xCoord="161" yCoord="56"/>

--- a/src/main/resources/Example nets/alternating-bit-protocol-transport.tapn
+++ b/src/main/resources/Example nets/alternating-bit-protocol-transport.tapn
@@ -47,12 +47,10 @@ Try to experiment with the values of the constants deadline and delay in order t
       <arcpath arcPointType="false" id="1" xCoord="525" yCoord="645"/>
     </arc>
     <arc id="Receiver_0_A to Receive_0" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="Receiver_0_A" target="Receive_0" type="timed" weight="1">
-      <arcpath arcPointType="false" id="0" xCoord="629" yCoord="798"/>
-      <arcpath arcPointType="false" id="1" xCoord="685" yCoord="810"/>
-      <arcpath arcPointType="false" id="2" xCoord="734" yCoord="809"/>
-      <arcpath arcPointType="false" id="3" xCoord="734" yCoord="149"/>
-      <arcpath arcPointType="false" id="4" xCoord="660" yCoord="148"/>
-      <arcpath arcPointType="false" id="5" xCoord="630" yCoord="164"/>
+      <arcpath arcPointType="false" id="0" xCoord="630" yCoord="795"/>
+      <arcpath arcPointType="false" id="2" xCoord="735" yCoord="795"/>
+      <arcpath arcPointType="false" id="3" xCoord="735" yCoord="165"/>
+      <arcpath arcPointType="false" id="5" xCoord="630" yCoord="165"/>
     </arc>
     <arc id="Sender_0_A to Send_0" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="Sender_0_A" target="Send_0" type="timed" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="165" yCoord="90"/>
@@ -163,11 +161,11 @@ Try to experiment with the values of the constants deadline and delay in order t
     </arc>
     <arc id="Ack_rec_1 to Sender_0_A" inscription="1" nameOffsetX="0" nameOffsetY="0" source="Ack_rec_1" target="Sender_0_A" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="165" yCoord="740"/>
-      <arcpath arcPointType="false" id="1" xCoord="148" yCoord="808"/>
+      <arcpath arcPointType="false" id="1" xCoord="165" yCoord="808"/>
       <arcpath arcPointType="false" id="2" xCoord="73" yCoord="808"/>
-      <arcpath arcPointType="false" id="3" xCoord="73" yCoord="43"/>
-      <arcpath arcPointType="false" id="4" xCoord="178" yCoord="43"/>
-      <arcpath arcPointType="false" id="5" xCoord="170" yCoord="61"/>
+      <arcpath arcPointType="false" id="3" xCoord="73" yCoord="40"/>
+      <arcpath arcPointType="false" id="4" xCoord="165" yCoord="40"/>
+      <arcpath arcPointType="false" id="5" xCoord="165" yCoord="60"/>
     </arc>
     <arc id="Send_0 to Medium_A" inscription="1" nameOffsetX="0" nameOffsetY="0" source="Send_0" target="Medium_A" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="180" yCoord="164"/>

--- a/src/main/resources/Example nets/alternating-bit-protocol.tapn
+++ b/src/main/resources/Example nets/alternating-bit-protocol.tapn
@@ -53,12 +53,10 @@ The query asks about violation of the synchronization between sender and receive
       <arcpath arcPointType="false" id="1" xCoord="499" yCoord="615"/>
     </arc>
     <arc id="Receiver_A to Receive_0" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="Receiver_A" target="Receive_0" type="timed" weight="1">
-      <arcpath arcPointType="false" id="0" xCoord="629" yCoord="796"/>
-      <arcpath arcPointType="false" id="1" xCoord="676" yCoord="801"/>
-      <arcpath arcPointType="false" id="2" xCoord="725" yCoord="800"/>
-      <arcpath arcPointType="false" id="3" xCoord="725" yCoord="140"/>
-      <arcpath arcPointType="false" id="4" xCoord="651" yCoord="139"/>
-      <arcpath arcPointType="false" id="5" xCoord="615" yCoord="160"/>
+      <arcpath arcPointType="false" id="0" xCoord="630" yCoord="795"/>
+      <arcpath arcPointType="false" id="2" xCoord="735" yCoord="795"/>
+      <arcpath arcPointType="false" id="3" xCoord="735" yCoord="165"/>
+      <arcpath arcPointType="false" id="5" xCoord="630" yCoord="165"/>
     </arc>
     <arc id="Sender_A to Send_0" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="Sender_A" target="Send_0" type="timed" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="165" yCoord="90"/>
@@ -169,11 +167,11 @@ The query asks about violation of the synchronization between sender and receive
     </arc>
     <arc id="Ack_rec_1 to Sender_A" inscription="1" nameOffsetX="0" nameOffsetY="0" source="Ack_rec_1" target="Sender_A" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="165" yCoord="740"/>
-      <arcpath arcPointType="false" id="1" xCoord="140" yCoord="785"/>
+      <arcpath arcPointType="false" id="1" xCoord="165" yCoord="785"/>
       <arcpath arcPointType="false" id="2" xCoord="80" yCoord="785"/>
-      <arcpath arcPointType="false" id="3" xCoord="80" yCoord="50"/>
-      <arcpath arcPointType="false" id="4" xCoord="155" yCoord="50"/>
-      <arcpath arcPointType="false" id="5" xCoord="159" yCoord="61"/>
+      <arcpath arcPointType="false" id="3" xCoord="80" yCoord="40"/>
+      <arcpath arcPointType="false" id="4" xCoord="165" yCoord="40"/>
+      <arcpath arcPointType="false" id="5" xCoord="165" yCoord="60"/>
     </arc>
     <arc id="Send_0 to Medium_A" inscription="1" nameOffsetX="0" nameOffsetY="0" source="Send_0" target="Medium_A" type="normal" weight="1">
       <arcpath arcPointType="false" id="0" xCoord="180" yCoord="164"/>

--- a/src/main/resources/Example nets/token-ring.tapn
+++ b/src/main/resources/Example nets/token-ring.tapn
@@ -211,7 +211,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="760" yCoord="265"/>
-      <arcpath arcPointType="false" id="1" xCoord="620" yCoord="233"/>
+      <arcpath arcPointType="false" id="1" xCoord="624" yCoord="237"/>
       <arcpath arcPointType="false" id="2" xCoord="479" yCoord="266"/>
     </arc>
     <arc id="state2mainproc" inscription="[0,inf)" nameOffsetX="123" nameOffsetY="23" source="state" target="mainprocess" type="timed" weight="1">
@@ -261,7 +261,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="479" yCoord="273"/>
-      <arcpath arcPointType="false" id="1" xCoord="626" yCoord="303"/>
+      <arcpath arcPointType="false" id="1" xCoord="630" yCoord="307"/>
       <arcpath arcPointType="false" id="2" xCoord="759" yCoord="275"/>
     </arc>
     <arc id="otherproc2state" inscription="1" nameOffsetX="52" nameOffsetY="-25" source="otherprocess" target="state" type="normal" weight="1">
@@ -315,7 +315,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="185" yCoord="265"/>
-      <arcpath arcPointType="false" id="1" xCoord="320" yCoord="233"/>
+      <arcpath arcPointType="false" id="1" xCoord="324" yCoord="237"/>
       <arcpath arcPointType="false" id="2" xCoord="450" yCoord="266"/>
     </arc>
     <arc id="state2otherproc" inscription="[0,inf)" nameOffsetX="38" nameOffsetY="20" source="state" target="otherprocess" type="timed" weight="1">
@@ -369,7 +369,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="450" yCoord="273"/>
-      <arcpath arcPointType="false" id="1" xCoord="320" yCoord="302"/>
+      <arcpath arcPointType="false" id="1" xCoord="324" yCoord="306"/>
       <arcpath arcPointType="false" id="2" xCoord="184" yCoord="275"/>
     </arc>
   </net>


### PR DESCRIPTION
When saving a net, the arcs and their labels won't change position when opening them again.

Solves https://bugs.launchpad.net/tapaal/+bug/1988737.