### PR TITLE
Update undo token count 1995844

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/undo/Colored/ColoredPlaceMarkingEditCommand.java
+++ b/src/main/java/net/tapaal/gui/petrinet/undo/Colored/ColoredPlaceMarkingEditCommand.java
@@ -23,6 +23,8 @@ public class ColoredPlaceMarkingEditCommand extends Command {
     private final List<ColoredTimeInvariant> oldCtiList;
     private final ArcExpression oldExpression;
     private final ArcExpression newExpression;
+    private final int oldTokenCount;
+    private final int newTokenCount;
 
     public ColoredPlaceMarkingEditCommand(
         ArrayList<TimedToken> tokenList,
@@ -32,7 +34,9 @@ public class ColoredPlaceMarkingEditCommand extends Command {
         Context context,
         TimedPlaceComponent place,
         List<ColoredTimeInvariant> ctiList,
-        ColorType colorType1
+        ColorType colorType1,
+        int oldTokenCount,
+        int newTokenCount
     ){
         this.tokenList = tokenList;
         this.newTokenList = newTokenList;
@@ -44,6 +48,8 @@ public class ColoredPlaceMarkingEditCommand extends Command {
         this.newExpression = newExpression;
         this.oldColorType = place.underlyingPlace().getColorType();
         this.oldCtiList = place.underlyingPlace().getCtiList();
+        this.oldTokenCount = oldTokenCount;
+        this.newTokenCount = newTokenCount;
     }
 
     @Override
@@ -55,7 +61,7 @@ public class ColoredPlaceMarkingEditCommand extends Command {
         place.underlyingPlace().setColorType(oldColorType);
         place.underlyingPlace().setCtiList(oldCtiList);
         place.underlyingPlace().updateTokens(tokenList, oldExpression);
-
+        place.underlyingPlace().setNumberOfTokens(oldTokenCount);
 
         place.update(true);
         place.repaint();
@@ -70,6 +76,7 @@ public class ColoredPlaceMarkingEditCommand extends Command {
         place.underlyingPlace().setCtiList(ctiList);
         place.underlyingPlace().setColorType(colorType);
         place.underlyingPlace().updateTokens(newTokenList, newExpression);
+        place.underlyingPlace().setNumberOfTokens(newTokenCount);
 
         place.update(true);
         place.repaint();

--- a/src/main/java/pipe/gui/petrinet/editor/PlaceEditorPanel.java
+++ b/src/main/java/pipe/gui/petrinet/editor/PlaceEditorPanel.java
@@ -668,7 +668,6 @@ public class PlaceEditorPanel extends JPanel {
 		}
         doOkColors(newMarking);
 
-
 		TimeInvariant newInvariant = constructInvariant();
 		TimeInvariant oldInvariant = place.underlyingPlace().invariant();
 		if(!newInvariant.equals(oldInvariant)){
@@ -704,6 +703,7 @@ public class PlaceEditorPanel extends JPanel {
                 return;
             }
         } else {
+            int oldTokenCount = place.underlyingPlace().numberOfTokens();
             ArrayList<TimedToken> tokensToAdd = new ArrayList<>();
             ArrayList<TimedToken> oldTokenList = new ArrayList(context.activeModel().marking().getTokensFor(place.underlyingPlace()));
             List<ColoredTimeInvariant> ctiList = new ArrayList<>();
@@ -730,7 +730,7 @@ public class PlaceEditorPanel extends JPanel {
             if (!colorType.equals(place.underlyingPlace().getColorType())) {
                 updateArcsAccordingToColorType();
             }
-            Command command = new ColoredPlaceMarkingEditCommand(oldTokenList, tokensToAdd, originalExpression, newExpression, context, place, ctiList, colorType);
+            Command command = new ColoredPlaceMarkingEditCommand(oldTokenList, tokensToAdd, originalExpression, newExpression, context, place, ctiList, colorType, oldTokenCount, place.underlyingPlace().numberOfTokens());
             command.redo();
             context.undoManager().addEdit(command);
         }


### PR DESCRIPTION
When editing a place (removing/adding a token) and undoing this change, the number of tokens is updated accordingly.

Solves https://bugs.launchpad.net/tapaal/+bug/1995844.