### PR TITLE
Zoom-update-2004559

### DIFF
--- a/src/main/java/net/tapaal/gui/GuiFrameController.java
+++ b/src/main/java/net/tapaal/gui/GuiFrameController.java
@@ -187,10 +187,7 @@ public final class GuiFrameController implements GuiFrameControllerActions{
 
     @Override
     public void showNewPNDialog() {
-
         NewTAPNPanel.showNewTapnPanel(guiFrameDirectAccess);
-
-
     }
 
     @Override

--- a/src/main/java/pipe/gui/petrinet/PetriNetTab.java
+++ b/src/main/java/pipe/gui/petrinet/PetriNetTab.java
@@ -1718,6 +1718,7 @@ public class PetriNetTab extends JSplitPane implements TabActions {
 		undoManager.setApp(app);
 
 		updateFeatureText();
+		updateZoom();
 
 		//XXX
 		if (isInAnimationMode()) {
@@ -2336,6 +2337,11 @@ public class PetriNetTab extends JSplitPane implements TabActions {
 		managerRef.get().deregisterManager();
         managerRef.setReference(newManager);
 		managerRef.get().registerManager(drawingSurface, guiModelManager);
+    }
+
+    public void updateZoom() {
+	    int zoom = drawingSurface().getZoom();
+	    zoomTo(zoom);
     }
 
     public void updateFeatureText() {


### PR DESCRIPTION
When creating new tabs or switching between tabs, the zoom percentages will update according to which tab is selected.

Solves https://bugs.launchpad.net/tapaal/+bug/2004559.