### PR TITLE
Timed cpn invariants 2007299

### DIFF
--- a/src/main/java/dk/aau/cs/verification/TAPNComposer.java
+++ b/src/main/java/dk/aau/cs/verification/TAPNComposer.java
@@ -228,6 +228,7 @@ public class TAPNComposer implements ITAPNComposer {
 					} else {
 						place = new LocalTimedPlace(uniquePlaceName, new TimeInvariant(timedPlace.invariant().isUpperNonstrict(), new IntBound(timedPlace.invariant().upperBound().value())),timedPlace.getColorType());
 					}
+					place.setCtiList(timedPlace.getCtiList());
 					constructedModel.add(place);
 					mapping.addMapping(tapn.name(), timedPlace.name(), uniquePlaceName);
                     


### PR DESCRIPTION
Actual invariants should be shown when unfolding a timed CPN net.

Solves https://bugs.launchpad.net/tapaal/+bug/2007299.