### PR TITLE
Missing brackets 2012121

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AndExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AndExpression.java
@@ -15,16 +15,20 @@ public class AndExpression extends GuardExpression {
         this.left = left;
         this.right = right;
     }
+
     public GuardExpression getLeftExpression(){
         return this.left;
     }
+
     public GuardExpression getRightExpression(){
         return this.right;
     }
+
     @Override
     public GuardExpression replace(Expression object1, Expression object2){
         return replace(object1,object2,false);
     }
+
     @Override
     public GuardExpression replace(Expression object1, Expression object2, boolean replaceAllInstances) {
         if (this == object1 && object2 instanceof GuardExpression) {
@@ -78,7 +82,7 @@ public class AndExpression extends GuardExpression {
 
     @Override
     public String toString() {
-        return left.toString() + " and " + right.toString();
+        return "(" + left.toString() + " and " + right.toString() + ")";
     }
 
     @Override
@@ -87,10 +91,9 @@ public class AndExpression extends GuardExpression {
     @Override
     public ExprStringPosition[] getChildren() {
         ExprStringPosition[] children = new ExprStringPosition[2];
-        int endPrev = 0;
-
-        int start = 0;
-        int end = 0;
+        int start = 1;
+        int endPrev;
+        int end;
 
         end = start + left.toString().length();
         endPrev = end;
@@ -117,5 +120,4 @@ public class AndExpression extends GuardExpression {
     public GuardExpression copy() {
        return new AndExpression(left, right);
     }
-
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/Expression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/Expression.java
@@ -45,6 +45,7 @@ public abstract class Expression {
     }
 
     public abstract Expression replace(Expression object1, Expression object2,boolean replaceAllInstances);
+
     public abstract Expression replace(Expression object1, Expression object2);
 
     public abstract Expression copy();
@@ -60,5 +61,6 @@ public abstract class Expression {
     public abstract void getValues(ExprValues exprValues);
 
     public abstract void getVariables(Set<Variable> variables);
+
     public abstract boolean containsColor(Color color);
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/GuardExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/GuardExpression.java
@@ -6,17 +6,18 @@ import dk.aau.cs.model.CPN.Variable;
 import java.util.Set;
 
 public abstract class GuardExpression extends Expression {
-
     protected GuardExpression parent;
     protected ColorType colorType;
 
     public GuardExpression getParent() { return parent; }
+
     public void setParent(GuardExpression parent) { this.parent = parent; }
 
     public ColorType getColorType() { return colorType; }
 
     @Override
     public abstract GuardExpression replace(Expression object1, Expression object2, boolean replaceAllInstances);
+
     @Override
     public abstract GuardExpression replace(Expression object1, Expression object2);
 
@@ -26,7 +27,7 @@ public abstract class GuardExpression extends Expression {
     @Override
     public abstract Expression findFirstPlaceHolder();
 
-
     public abstract void getVariables(Set<Variable> variables);
+
     public abstract Boolean eval(ExpressionContext context);
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/OrExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/OrExpression.java
@@ -25,6 +25,7 @@ public class OrExpression extends GuardExpression {
     public GuardExpression getLeftExpression() {
         return this.left;
     }
+
     public GuardExpression getRightExpression() {
         return this.right;
     }
@@ -35,10 +36,9 @@ public class OrExpression extends GuardExpression {
     @Override
     public ExprStringPosition[] getChildren() {
         ExprStringPosition[] children = new ExprStringPosition[2];
-
-        int endPrev = 0;
-        int start = 0;
-        int end = 0;
+        int start = 1;
+        int endPrev;
+        int end;
 
         end = start + left.toString().length();
         endPrev = end;
@@ -118,7 +118,6 @@ public class OrExpression extends GuardExpression {
 
     @Override
     public String toString() {
-        return left.toString() + " or " + right.toString();
+        return "(" + left.toString() + " or " + right.toString() + ")";
     }
-
 }


### PR DESCRIPTION
Parentheses are added to the guard expression around "or" and "and" expressions.

Solves https://bugs.launchpad.net/tapaal/+bug/2012121.