### PR TITLE
Untiming engine change 2020433

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/TabTransformer.java
+++ b/src/main/java/net/tapaal/gui/petrinet/TabTransformer.java
@@ -108,7 +108,6 @@ public class TabTransformer {
                     template.model().add(arc2.underlyingArc());
 
                 }
-
             }
         }
     }

--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -926,7 +926,8 @@ public class QueryDialog extends JPanel {
             lens.isGame(),
             (newProperty.toString().contains("EG") || newProperty.toString().contains("AF")) && highestNetDegree > 2,
             newProperty.hasNestedPathQuantifiers(),
-            lens.isColored()
+            lens.isColored(),
+            lens.isColored() && !lens.isTimed()
         };
 
 

--- a/src/main/java/net/tapaal/gui/petrinet/verification/EngineSupportOptions.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/EngineSupportOptions.java
@@ -16,11 +16,13 @@ public class EngineSupportOptions {
     public final boolean supportEGorAFWithNetDegreeGreaterThan2;
     public final boolean supportNestedQuantifications;
     public final boolean supportColored;
+    public final boolean supportOnlyUntimed;
 
     public final boolean[] optionsArray;
     public EngineSupportOptions(String nameString, boolean supportFastestTrace, boolean supportDeadlockNetdegree2EForAG, boolean supportDeadlockEGorAF, boolean supportDeadlockWithInhib,
                                 boolean supportWeights, boolean supportInhibArcs, boolean supportUrgentTransitions, boolean supportEGorAF, boolean supportStrictNets, boolean supportTimedNets,
-                                boolean supportDeadlockNetdegreeGreaterThan2, boolean supportGames, boolean supportEGorAFWithNetDegreeGreaterThan2, boolean supportNestedQuantifications, boolean supportColored){
+                                boolean supportDeadlockNetdegreeGreaterThan2, boolean supportGames, boolean supportEGorAFWithNetDegreeGreaterThan2, boolean supportNestedQuantifications,
+                                boolean supportColored, boolean supportOnlyUntimed){
         this.nameString = nameString;
         this.supportFastestTrace = supportFastestTrace;
         this.supportDeadlockNetdegree2EForAG = supportDeadlockNetdegree2EForAG;
@@ -36,9 +38,10 @@ public class EngineSupportOptions {
         this.supportEGorAFWithNetDegreeGreaterThan2 = supportEGorAFWithNetDegreeGreaterThan2;
         this.supportNestedQuantifications = supportNestedQuantifications;
         this.supportColored = supportColored;
+        this.supportOnlyUntimed = supportOnlyUntimed;
         this.optionsArray = new boolean[]{supportFastestTrace, supportDeadlockNetdegree2EForAG, supportDeadlockEGorAF, supportDeadlockWithInhib,
             supportWeights, supportInhibArcs, supportUrgentTransitions, supportEGorAF, supportStrictNets, supportTimedNets, supportDeadlockNetdegreeGreaterThan2,
-            supportGames, supportEGorAFWithNetDegreeGreaterThan2, supportNestedQuantifications,supportColored};
+            supportGames, supportEGorAFWithNetDegreeGreaterThan2, supportNestedQuantifications, supportColored, supportOnlyUntimed};
     }
 
     public boolean areOptionsSupported(boolean[] queryOptions){

--- a/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALBroadcastDegree2Options.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALBroadcastDegree2Options.java
@@ -19,6 +19,7 @@ public class UPPAALBroadcastDegree2Options extends EngineSupportOptions {
             false, //support games
             true,//support EG or AF with net degree > 2);
             false, //support for nested quantification
+            false,
             false
         );
     }

--- a/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALBroadcastOptions.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALBroadcastOptions.java
@@ -19,6 +19,7 @@ public class UPPAALBroadcastOptions extends EngineSupportOptions {
             false, //support games
             true, //support EG or AF with net degree > 2);
             false, //support for nested quantification
+           false,
            false
        );
     }

--- a/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALCombiOptions.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALCombiOptions.java
@@ -19,6 +19,7 @@ public class UPPAALCombiOptions extends EngineSupportOptions {
             false, //support games
             true, //support EG or AF with net degree > 2);
             false, //support for nested quantification
+            false,
             false
         );
     }

--- a/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALOptimizedStandardOptions.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALOptimizedStandardOptions.java
@@ -19,6 +19,7 @@ public class UPPAALOptimizedStandardOptions extends EngineSupportOptions {
             false, //support games
             false,//support EG or AF with net degree > 2);
             false, //support for nested quantification
+            false,
             false
         );
     }

--- a/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALStandardOptions.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/UPPAALStandardOptions.java
@@ -19,6 +19,7 @@ public class UPPAALStandardOptions extends EngineSupportOptions {
             false, //support games
             false, //support EG or AF with net degree > 2);
             false, //support for nested quantification,
+            false,
             false
         );
     }

--- a/src/main/java/net/tapaal/gui/petrinet/verification/VerifyDTAPNEngineOptions.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/VerifyDTAPNEngineOptions.java
@@ -19,7 +19,8 @@ public class VerifyDTAPNEngineOptions extends EngineSupportOptions {
             true, //support games
             true, //support EG or AF with net degree > 2);
             false, //support for nested quantification
-            true
+            true,
+            false
         );
     }
 }

--- a/src/main/java/net/tapaal/gui/petrinet/verification/VerifyPNEngineOptions.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/VerifyPNEngineOptions.java
@@ -19,6 +19,7 @@ public class VerifyPNEngineOptions extends EngineSupportOptions {
             false, //support games
             true, //support EG or AF with net degree > 2
             true,//support for nested quantification
+            true,
             true
         );
     }

--- a/src/main/java/net/tapaal/gui/petrinet/verification/VerifyTAPNEngineOptions.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/VerifyTAPNEngineOptions.java
@@ -19,7 +19,8 @@ public class VerifyTAPNEngineOptions extends EngineSupportOptions {
             false, // support games
             false, // support EG or AF with net degree > 2
             false, // support for nested quantification
-            true
+            true,
+            false
         );
     }
 }

--- a/src/main/java/pipe/gui/petrinet/PetriNetTab.java
+++ b/src/main/java/pipe/gui/petrinet/PetriNetTab.java
@@ -227,7 +227,8 @@ public class PetriNetTab extends JSplitPane implements TabActions {
                 tab.lens.isGame(),
                 (q.getProperty() instanceof TCTLEGNode || q.getProperty() instanceof TCTLAFNode) && net.getHighestNetDegree() > 2,
                 q.hasUntimedOnlyProperties(),
-                tab.lens.isColored()
+                tab.lens.isColored(),
+                tab.lens.isColored() && !tab.lens.isTimed()
             };
 
             boolean hasEngine = tab.checkCurrentEngine(q.getReductionOption(), queryOptions);
@@ -264,6 +265,7 @@ public class PetriNetTab extends JSplitPane implements TabActions {
                 q.setReductionOption(ReductionOption.VerifyPN);
                 q.setUseOverApproximationEnabled(false);
                 q.setUseUnderApproximationEnabled(false);
+                q.setCategory(TAPNQuery.QueryCategory.CTL);
             } else {
                 if (q.getCategory() == TAPNQuery.QueryCategory.LTL) {
                     queriesToRemove.add(q);


### PR DESCRIPTION
Fixed colored untimed nets not updating engine selection in queries correctly.

Solves https://bugs.launchpad.net/tapaal/+bug/2020433.