### PR TITLE
Inhibitor arcs do not make the net colored anymore (fixes workflow analysis but 2035728)

### DIFF
--- a/src/main/java/dk/aau/cs/model/tapn/TimedArcPetriNet.java
+++ b/src/main/java/dk/aau/cs/model/tapn/TimedArcPetriNet.java
@@ -101,7 +101,7 @@ public class TimedArcPetriNet {
                 break;
             }
         }
-        if (hasColors || values.getColorTypes().size() > 1 || !values.getVariables().isEmpty()) {
+        if (hasColors || values.getColorTypes().stream().distinct().count()  > 1 || !values.getVariables().isEmpty()) {
             return true;
         }
 


### PR DESCRIPTION
Fix for bug https://bugs.launchpad.net/tapaal/+bug/2035728 where two or more inhibitor arcs made the net colored and made workflow analysis to fail. Inhibitor arcs added the same color type to values multiple times so now we count only the unique color types.