### PR TITLE
Fix for reset of colored tokens - bug 2037705

### DIFF
--- a/src/main/java/dk/aau/cs/model/tapn/TimedPlace.java
+++ b/src/main/java/dk/aau/cs/model/tapn/TimedPlace.java
@@ -79,7 +79,8 @@ public abstract class TimedPlace {
     }
 
     public void resetNumberOfTokens() {
-        numberOfTokens = 0;
+        this.numberOfTokens = 0;
+        this.tokens().clear();
     }
 
     /**


### PR DESCRIPTION
Fixes bug when after removing colored tokens the GUI still showed the previous count. Bug: https://bugs.launchpad.net/tapaal/+bug/2037705