### PR TITLE
Smart draw layout - fix 2038420

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/smartdraw/SmartDrawDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/smartdraw/SmartDrawDialog.java
@@ -245,6 +245,16 @@ public class SmartDrawDialog extends JDialog {
 		drawButton.requestFocus();
 		
 		setContentPane(mainPanel);
+
+		int extraWidth = 100;
+
+		Dimension preferredSize = mainPanel.getPreferredSize();
+		int preferredWidth = preferredSize.width + extraWidth;
+		int preferredHeight = preferredSize.height;
+
+		Dimension newPreferredSize = new Dimension(preferredWidth, preferredHeight);
+
+		mainPanel.setPreferredSize(newPreferredSize);
 	}
 	
 	private void initAdvancedOptionsPanel() {
@@ -566,8 +576,6 @@ public class SmartDrawDialog extends JDialog {
 		gbc.fill = GridBagConstraints.BOTH;
 		gbc.insets = new Insets(10, 20, 10, 0);
 		gbc.anchor = GridBagConstraints.NORTHWEST;
-
-		spacingPanel.setPreferredSize(new Dimension(400, getHeight()));
 
 		mainPanel.add(spacingPanel, gbc);
 	}

--- a/src/main/java/net/tapaal/gui/petrinet/smartdraw/SmartDrawDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/smartdraw/SmartDrawDialog.java
@@ -566,6 +566,9 @@ public class SmartDrawDialog extends JDialog {
 		gbc.fill = GridBagConstraints.BOTH;
 		gbc.insets = new Insets(10, 20, 10, 0);
 		gbc.anchor = GridBagConstraints.NORTHWEST;
+
+		spacingPanel.setPreferredSize(new Dimension(400, getHeight()));
+
 		mainPanel.add(spacingPanel, gbc);
 	}
 

--- a/src/main/java/net/tapaal/gui/petrinet/smartdraw/SmartDrawDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/smartdraw/SmartDrawDialog.java
@@ -244,8 +244,6 @@ public class SmartDrawDialog extends JDialog {
 		this.getRootPane().setDefaultButton(drawButton);
 		drawButton.requestFocus();
 		
-		setContentPane(mainPanel);
-
 		int extraWidth = 100;
 
 		Dimension preferredSize = mainPanel.getPreferredSize();
@@ -255,6 +253,13 @@ public class SmartDrawDialog extends JDialog {
 		Dimension newPreferredSize = new Dimension(preferredWidth, preferredHeight);
 
 		mainPanel.setPreferredSize(newPreferredSize);
+
+		JScrollPane scrollPane = new JScrollPane(mainPanel);
+		scrollPane.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED);
+		scrollPane.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+		scrollPane.setBorder(null);
+
+		setContentPane(scrollPane);
 	}
 	
 	private void initAdvancedOptionsPanel() {


### PR DESCRIPTION
Fixes:
https://bugs.launchpad.net/tapaal/+bug/2038420

+ Increased preferred width of smart draw dialog with 100
+ Added scrollbar for operating systems that still allow resizing after setResizable(false) is set