### PR TITLE
Initial markings disappearing - fix 2038418

### DIFF
--- a/src/main/java/dk/aau/cs/model/tapn/TimedPlace.java
+++ b/src/main/java/dk/aau/cs/model/tapn/TimedPlace.java
@@ -80,6 +80,10 @@ public abstract class TimedPlace {
 
     public void resetNumberOfTokens() {
         this.numberOfTokens = 0;
+    }
+
+    public void resetNumberOfTokensColor() {
+        resetNumberOfTokens();
         this.tokens().clear();
     }
 

--- a/src/main/java/pipe/gui/petrinet/editor/PlaceEditorPanel.java
+++ b/src/main/java/pipe/gui/petrinet/editor/PlaceEditorPanel.java
@@ -745,7 +745,7 @@ public class PlaceEditorPanel extends JPanel {
                     tokensToAdd.addAll(cm.getTokens(place.underlyingPlace()));
                 }
             } else {
-                place.underlyingPlace().resetNumberOfTokens();
+                place.underlyingPlace().resetNumberOfTokensColor();
             }
 
             for (int i = 0; i < timeConstraintListModel.size(); i++) {

--- a/src/main/java/pipe/gui/petrinet/graphicElements/tapn/TimedPlaceComponent.java
+++ b/src/main/java/pipe/gui/petrinet/graphicElements/tapn/TimedPlaceComponent.java
@@ -331,7 +331,7 @@ public class TimedPlaceComponent extends Place {
                 g.drawString("#" + marking, x, y + 20);
             } else if (marking > 9) {
                 g.drawString("#" + marking, x + 2, y + 20);
-            } else {
+            } else if (marking > 0) {
                 g.drawString("#" + marking, x + 6, y + 20);
             }
         }


### PR DESCRIPTION
Fixes:
https://bugs.launchpad.net/tapaal/+bug/2038418

+ Fixed issue where initial markings from non-colored nets would disappear after changes during simulation.
+ Fixed issue where places with zero tokens in CPN would display as "#0" instead of simply being empty