### PR TITLE
Broken history CPN - fix 2040246

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/ColorMultiset.java
+++ b/src/main/java/dk/aau/cs/model/CPN/ColorMultiset.java
@@ -57,7 +57,7 @@ public class ColorMultiset implements Map<Color, Integer> {
 
     @Override
     public Integer put(Color color, Integer integer) {
-        if (color.getColorType() != colorType) {
+        if (!(color.getColorType().equals(colorType))) {
             throw new IllegalArgumentException(String.format("Type mismatch: Attempted to put %s in multiset of type %s", color.getName(), colorType.getName()));
         }
         //If at most 0, clean key from set


### PR DESCRIPTION
Fixes:
https://bugs.launchpad.net/tapaal/+bug/2040246

+ Changes (ColorMultiset.java:80) to compare with objects equals() function instead of comparing their memory address