### PR TITLE
Missing error dialogs - fix 2044661

### DIFF
--- a/src/main/java/dk/aau/cs/verification/ProcessRunner.java
+++ b/src/main/java/dk/aau/cs/verification/ProcessRunner.java
@@ -7,6 +7,7 @@ import java.io.StringReader;
 
 import dk.aau.cs.debug.Logger;
 import dk.aau.cs.util.MemoryMonitor;
+import dk.aau.cs.verification.VerifyTAPN.VerifyDTAPN;
 
 public class ProcessRunner {
 
@@ -19,15 +20,23 @@ public class ProcessRunner {
 
 	private boolean error = false;
 
-	public ProcessRunner(String file, String arguments) {
+	public ProcessRunner(String file, String arguments, ModelChecker modelChecker) {
 		// this.setName("verification thread");
 
 		if (file == null || file.isEmpty()) {
-			throw new IllegalArgumentException("file");
+			if (modelChecker == null) {
+				throw new IllegalArgumentException("file");
+			}
+
+			modelChecker.setup(); // Ask user to setup engine
 		}
 
 		this.file = file;
 		this.arguments = arguments;
+	}
+
+	public ProcessRunner(String file, String arguments) {
+		this(file, arguments, null);
 	}
 
 	public long getRunningTime() {

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPN.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPN.java
@@ -462,7 +462,7 @@ public class VerifyDTAPN implements ModelChecker{
 	}
 
     public String getHelpOptions() {
-        runner = new ProcessRunner(verifydtapnpath, "--help");
+        runner = new ProcessRunner(verifydtapnpath, "--help", this);
         runner.run();
 
         if (!runner.error()) {

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPN.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPN.java
@@ -555,7 +555,7 @@ public class VerifyPN implements ModelChecker {
     }
 
     public String getHelpOptions() {
-        runner = new ProcessRunner(verifypnpath, "--help");
+        runner = new ProcessRunner(verifypnpath, "--help", this);
         runner.run();
 
         if (!runner.error()) {

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPN.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPN.java
@@ -437,7 +437,7 @@ public class VerifyTAPN implements ModelChecker {
 	}
 
     public String getHelpOptions() {
-        runner = new ProcessRunner(verifytapnpath, "--help");
+        runner = new ProcessRunner(verifytapnpath, "--help", this);
         runner.run();
 
         if (!runner.error()) {

--- a/src/main/java/net/tapaal/gui/GuiFrameController.java
+++ b/src/main/java/net/tapaal/gui/GuiFrameController.java
@@ -494,7 +494,6 @@ public final class GuiFrameController implements GuiFrameControllerActions{
             JOptionPane.showMessageDialog(null, "There was a problem opening the default web browser \n" +
                             "Please open the url in your browser by entering " + url.toString(),
                     "Error opening browser", JOptionPane.ERROR_MESSAGE);
-            e.printStackTrace();
         }
     }
 

--- a/src/main/java/net/tapaal/gui/GuiFrameController.java
+++ b/src/main/java/net/tapaal/gui/GuiFrameController.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.lang.UnsupportedOperationException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -487,7 +488,7 @@ public final class GuiFrameController implements GuiFrameControllerActions{
         //open the default browser on this page
         try {
             java.awt.Desktop.getDesktop().browse(url);
-        } catch (IOException e) {
+        } catch (IOException | UnsupportedOperationException e) {
             Logger.log("Cannot open the browser.");
             e.printStackTrace();
             JOptionPane.showMessageDialog(null, "There was a problem opening the default web browser \n" +


### PR DESCRIPTION
Fixes:
https://bugs.launchpad.net/tapaal/+bug/2044661

+ When no engine is selected and the user tries to open batch processing it will now ask them to set the missing ones
+ Added error dialogue when trying to open a standard browser on a platform where it is not supported