### PR TITLE
NPE Color semantics - fix 2045061

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/TabTransformer.java
+++ b/src/main/java/net/tapaal/gui/petrinet/TabTransformer.java
@@ -194,8 +194,6 @@ public class TabTransformer {
 
                 //kind of hack to convert from coloredTokens to uncolored
                 if (place.numberOfTokens() > 0) {
-                    System.out.println(numberOfTokens);
-                    System.out.println(place.numberOfTokens());
                     Vector<ColorExpression> v = new Vector<>();
                     v.add(new DotConstantExpression());
                     Vector<ArcExpression> numbOfExpression = new Vector<>();


### PR DESCRIPTION
Fixes:
https://bugs.launchpad.net/tapaal/+bug/2045061

+ Fixed error when converting CPN with AllExpressions to Noncolored nets.