### PR TITLE
Wrong k-bound passed when using approximation with raw verification - fix 2052379

### DIFF
--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
@@ -112,7 +112,9 @@ public class VerifyDTAPNOptions extends VerifyTAPNOptions {
                 } else {
                     result.append(kBoundArg());
                 }
-            }
+            } else {
+				result.append(kBoundArg());
+			}
             
             return result.append(rawVerificationOptions).toString();
         }

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
@@ -103,6 +103,9 @@ public class VerifyDTAPNOptions extends VerifyTAPNOptions {
 		StringBuilder result = new StringBuilder();
 	
 		if (useRawVerification) {
+			if (rawVerificationOptions != null) {
+                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+            }
             return result.append(rawVerificationOptions).toString();
         }
 

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
@@ -103,10 +103,17 @@ public class VerifyDTAPNOptions extends VerifyTAPNOptions {
 		StringBuilder result = new StringBuilder();
 	
 		if (useRawVerification) {
-			// TODO: temporary fix overriding k-bound if using approximation with raw verification
-			if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
-                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+            // TODO: temporary fix overriding k-bound if using approximation with raw verification
+            if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
+                kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
+														rawVerificationOptions.contains("-k");
+                if (kBoundPresentInRawVerificationOptions) {
+                    rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+                } else {
+                    result.append(kBoundArg());
+                }
             }
+            
             return result.append(rawVerificationOptions).toString();
         }
 

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
@@ -102,17 +102,13 @@ public class VerifyDTAPNOptions extends VerifyTAPNOptions {
 	public String toString() {
 		StringBuilder result = new StringBuilder();
 	
-		if (useRawVerification) {
-            // TODO: temporary fix overriding k-bound if using approximation with raw verification
-            if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
-                kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
-														rawVerificationOptions.contains("-k");
-                if (kBoundPresentInRawVerificationOptions) {
-                    rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
-                } else {
-                    result.append(kBoundArg());
-                }
-            } else {
+		// TODO: temporary fix overriding k-bound if using approximation with raw verification
+		if (useRawVerification && rawVerificationOptions != null) {
+			kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
+													rawVerificationOptions.contains("-k");
+            if ((enabledOverApproximation || enabledUnderApproximation) && kBoundPresentInRawVerificationOptions) {
+                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+			} else if (!kBoundPresentInRawVerificationOptions) {
 				result.append(kBoundArg());
 			}
             

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
@@ -103,7 +103,8 @@ public class VerifyDTAPNOptions extends VerifyTAPNOptions {
 		StringBuilder result = new StringBuilder();
 	
 		if (useRawVerification) {
-			if (rawVerificationOptions != null) {
+			// TODO: temporary fix overriding k-bound if using approximation with raw verification
+			if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
                 rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
             }
             return result.append(rawVerificationOptions).toString();

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyDTAPNOptions.java
@@ -102,18 +102,9 @@ public class VerifyDTAPNOptions extends VerifyTAPNOptions {
 	public String toString() {
 		StringBuilder result = new StringBuilder();
 	
-		// TODO: temporary fix overriding k-bound if using approximation with raw verification
 		if (useRawVerification && rawVerificationOptions != null) {
-			kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
-													rawVerificationOptions.contains("-k");
-            if ((enabledOverApproximation || enabledUnderApproximation) && kBoundPresentInRawVerificationOptions) {
-                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
-			} else if (!kBoundPresentInRawVerificationOptions) {
-				result.append(kBoundArg());
-			}
-            
-            return result.append(rawVerificationOptions).toString();
-        }
+			return rawVerificationString(rawVerificationOptions, traceArg(traceOption));
+		}
 
         result.append(kBoundArg());
         result.append(deadTokenArg());

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
@@ -183,18 +183,9 @@ public class VerifyPNOptions extends VerifyTAPNOptions{
 	public String toString() {
 		StringBuilder result = new StringBuilder();
     
-        // TODO: temporary fix overriding k-bound if using approximation with raw verification
-		if (useRawVerification && rawVerificationOptions != null) {
-			kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
-													rawVerificationOptions.contains("-k");
-            if ((enabledOverApproximation || enabledUnderApproximation) && kBoundPresentInRawVerificationOptions) {
-                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
-			} else if (!kBoundPresentInRawVerificationOptions) {
-				result.append(kBoundArg());
-			}
-            
-            return result.append(rawVerificationOptions).toString();
-        }
+        if (useRawVerification && rawVerificationOptions != null) {
+			return rawVerificationString(rawVerificationOptions, traceMap.get(traceOption));
+		}
 
 		result.append(kBoundArg());
 

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
@@ -4,8 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import javax.swing.JOptionPane;
-
 import net.tapaal.gui.petrinet.verification.TAPNQuery.SearchOption;
 import net.tapaal.gui.petrinet.verification.TAPNQuery.QueryReductionTime;
 import net.tapaal.gui.petrinet.verification.TAPNQuery.TraceOption;

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
@@ -184,7 +184,8 @@ public class VerifyPNOptions extends VerifyTAPNOptions{
 		StringBuilder result = new StringBuilder();
     
         if (useRawVerification) {
-            if (rawVerificationOptions != null) {
+            // TODO: temporary fix overriding k-bound if using approximation with raw verification
+            if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
                 rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
             }
             return result.append(rawVerificationOptions).toString();

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
@@ -184,11 +184,13 @@ public class VerifyPNOptions extends VerifyTAPNOptions{
 		StringBuilder result = new StringBuilder();
     
         if (useRawVerification) {
+            if (rawVerificationOptions != null) {
+                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+            }
             return result.append(rawVerificationOptions).toString();
         }
 
-		result.append("--k-bound ");
-		result.append(extraTokens+tokensInModel);
+		result.append(kBoundArg());
 
         var traceSwitch =traceMap.get(traceOption) ;
         if (traceSwitch != null) {

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
@@ -193,6 +193,8 @@ public class VerifyPNOptions extends VerifyTAPNOptions{
                 } else {
                     result.append(kBoundArg());
                 }
+            } else {
+                result.append(kBoundArg());
             }
             
             return result.append(rawVerificationOptions).toString();

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import javax.swing.JOptionPane;
+
 import net.tapaal.gui.petrinet.verification.TAPNQuery.SearchOption;
 import net.tapaal.gui.petrinet.verification.TAPNQuery.QueryReductionTime;
 import net.tapaal.gui.petrinet.verification.TAPNQuery.TraceOption;
@@ -186,8 +188,15 @@ public class VerifyPNOptions extends VerifyTAPNOptions{
         if (useRawVerification) {
             // TODO: temporary fix overriding k-bound if using approximation with raw verification
             if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
-                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+                kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
+														rawVerificationOptions.contains("-k");
+                if (kBoundPresentInRawVerificationOptions) {
+                    rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+                } else {
+                    result.append(kBoundArg());
+                }
             }
+            
             return result.append(rawVerificationOptions).toString();
         }
 

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPNOptions.java
@@ -183,19 +183,15 @@ public class VerifyPNOptions extends VerifyTAPNOptions{
 	public String toString() {
 		StringBuilder result = new StringBuilder();
     
-        if (useRawVerification) {
-            // TODO: temporary fix overriding k-bound if using approximation with raw verification
-            if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
-                kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
-														rawVerificationOptions.contains("-k");
-                if (kBoundPresentInRawVerificationOptions) {
-                    rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
-                } else {
-                    result.append(kBoundArg());
-                }
-            } else {
-                result.append(kBoundArg());
-            }
+        // TODO: temporary fix overriding k-bound if using approximation with raw verification
+		if (useRawVerification && rawVerificationOptions != null) {
+			kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
+													rawVerificationOptions.contains("-k");
+            if ((enabledOverApproximation || enabledUnderApproximation) && kBoundPresentInRawVerificationOptions) {
+                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+			} else if (!kBoundPresentInRawVerificationOptions) {
+				result.append(kBoundArg());
+			}
             
             return result.append(rawVerificationOptions).toString();
         }

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
@@ -114,7 +114,9 @@ public class VerifyTAPNOptions extends VerificationOptions{
                 } else {
                     result.append(kBoundArg());
                 }
-            }
+			} else {
+				result.append(kBoundArg());
+			}
             
             return result.append(rawVerificationOptions).toString();
         }

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
@@ -104,17 +104,13 @@ public class VerifyTAPNOptions extends VerificationOptions{
 	public String toString() {
 		StringBuilder result = new StringBuilder();
 		
-		if (useRawVerification) {
-            // TODO: temporary fix overriding k-bound if using approximation with raw verification
-            if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
-                kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
-														rawVerificationOptions.contains("-k");
-                if (kBoundPresentInRawVerificationOptions) {
-                    rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
-                } else {
-                    result.append(kBoundArg());
-                }
-			} else {
+		// TODO: temporary fix overriding k-bound if using approximation with raw verification
+		if (useRawVerification && rawVerificationOptions != null) {
+			kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
+													rawVerificationOptions.contains("-k");
+            if ((enabledOverApproximation || enabledUnderApproximation) && kBoundPresentInRawVerificationOptions) {
+                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+			} else if (!kBoundPresentInRawVerificationOptions) {
 				result.append(kBoundArg());
 			}
             

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
@@ -88,8 +88,12 @@ public class VerifyTAPNOptions extends VerificationOptions{
 	}
 
     public String kBoundArg() {
-        return " --k-bound " + (extraTokens+tokensInModel) + " ";
+        return "--k-bound " + kBound() + " ";
     }
+
+	public int kBound() {
+		return (extraTokens + tokensInModel);
+	}
 
     public String deadTokenArg() {
         return dontUseDeadPlaces ? " --keep-dead-tokens " : "";
@@ -100,6 +104,9 @@ public class VerifyTAPNOptions extends VerificationOptions{
 		StringBuilder result = new StringBuilder();
 		
 		if (useRawVerification) {
+			if (rawVerificationOptions != null) {
+                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+            }
             return result.append(rawVerificationOptions).toString();
         }
 

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
@@ -104,7 +104,8 @@ public class VerifyTAPNOptions extends VerificationOptions{
 		StringBuilder result = new StringBuilder();
 		
 		if (useRawVerification) {
-			if (rawVerificationOptions != null) {
+			// TODO: temporary fix overriding k-bound if using approximation with raw verification
+			if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
                 rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
             }
             return result.append(rawVerificationOptions).toString();

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNOptions.java
@@ -17,6 +17,7 @@ import pipe.gui.MessengerImpl;
 public class VerifyTAPNOptions extends VerificationOptions{
 
 	protected int tokensInModel;
+	protected boolean kBoundPresentInRawVerificationOptions;
 	private final boolean symmetry;
 	private final boolean discreteInclusion;
     private final boolean tarOption;
@@ -104,10 +105,17 @@ public class VerifyTAPNOptions extends VerificationOptions{
 		StringBuilder result = new StringBuilder();
 		
 		if (useRawVerification) {
-			// TODO: temporary fix overriding k-bound if using approximation with raw verification
-			if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
-                rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+            // TODO: temporary fix overriding k-bound if using approximation with raw verification
+            if (rawVerificationOptions != null && (enabledOverApproximation || enabledUnderApproximation)) {
+                kBoundPresentInRawVerificationOptions = rawVerificationOptions.contains("--k-bound") ||
+														rawVerificationOptions.contains("-k");
+                if (kBoundPresentInRawVerificationOptions) {
+                    rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "$1 " + kBound());
+                } else {
+                    result.append(kBoundArg());
+                }
             }
+            
             return result.append(rawVerificationOptions).toString();
         }
 
@@ -178,4 +186,7 @@ public class VerifyTAPNOptions extends VerificationOptions{
 		this.inclusionPlaces = inclusionPlaces;
 	}
 
+	public boolean kBoundPresentInRawVerificationOptions() {
+		return kBoundPresentInRawVerificationOptions;
+	}
 }

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNTraceParser.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNTraceParser.java
@@ -43,9 +43,12 @@ public class VerifyTAPNTraceParser {
 	
 		try {
 			StringBuilder sb = new StringBuilder();
-			int c;
-			while ((c = reader.read()) != -1) {
-				sb.append((char) c);
+			String line;
+			
+			while ((line = reader.readLine()) != null) {
+				if (line.contains("Trace")) continue;
+				sb.append(line);
+				sb.append(System.lineSeparator());
 			}
 
 			String xml = sb.toString();
@@ -151,6 +154,7 @@ public class VerifyTAPNTraceParser {
 			int startTraceList = xml.indexOf("<trace-list>");
 			if (startTrace == -1 && startTraceList == -1) return null;
 
+			System.out.println(xml);
 			DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 			return builder.parse(new InputSource(new StringReader(xml)));
 		} catch (ParserConfigurationException | IOException | SAXException e) {

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNTraceParser.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNTraceParser.java
@@ -2,6 +2,7 @@ package dk.aau.cs.verification.VerifyTAPN;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -13,10 +14,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import dk.aau.cs.model.CPN.ColorType;
 
 import org.w3c.dom.*;
-import org.xml.sax.ErrorHandler;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
 
 import dk.aau.cs.model.NTA.trace.TraceToken;
 import dk.aau.cs.model.tapn.TimedArcPetriNet;
@@ -40,7 +39,26 @@ public class VerifyTAPNTraceParser {
 	public TimedArcPetriNetTrace parseTrace(BufferedReader reader) {
 		TimedArcPetriNetTrace trace = new TimedArcPetriNetTrace(true);
 
-        Document document = loadDocument(reader);
+		Document document = null;
+	
+		try {
+			StringBuilder sb = new StringBuilder();
+			int c;
+			while ((c = reader.read()) != -1) {
+				sb.append((char) c);
+			}
+
+			String xml = sb.toString();
+			document = loadDocument(xml);
+		} catch (IOException e) {
+			e.printStackTrace();
+		} finally {
+			try {
+				reader.close();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+		}
 
         if(document == null) return null;
 
@@ -106,7 +124,6 @@ public class VerifyTAPNTraceParser {
 	private TimedTransitionStep parseTransitionStep(Element element) {
 		TimedTransition transition = tapn.getTransitionByName(element.getAttribute("id"));
 		
-		
 		NodeList tokenNodes = element.getChildNodes();
 		List<TimedToken> consumedTokens = new ArrayList<TimedToken>(tokenNodes.getLength());
 		for(int i = 0; i < tokenNodes.getLength(); i++){
@@ -127,42 +144,17 @@ public class VerifyTAPNTraceParser {
 		return new TimeDelayStep(new BigDecimal(element.getTextContent()));
 	}
 
-	private Document loadDocument(BufferedReader reader) {
+	private Document loadDocument(String xml) {
 		try {
-		    boolean shouldSkip = false;
-            // We need to reset the buffer if we a trace-list:
-            reader.mark(10000);
-            String line = reader.readLine();
-            try {
-                if(line.equals("Trace")) shouldSkip = true;
-                reader.reset();
-            } catch (NullPointerException e) {
-                return null;
-            }
-
-            if(shouldSkip) reader.readLine(); // first line is "Trace:"
+			// Check if valid xml
+			int startTrace = xml.indexOf("<trace>");
+			int startTraceList = xml.indexOf("<trace-list>");
+			if (startTrace == -1 && startTraceList == -1) return null;
 
 			DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-			builder.setErrorHandler(new ErrorHandler() {
-				
-				@Override
-				public void warning(SAXParseException exception) throws SAXException {
-					throw exception;
-				}
-				
-				@Override
-				public void fatalError(SAXParseException exception) throws SAXException {
-					throw exception;
-				}
-				
-				@Override
-				public void error(SAXParseException exception) throws SAXException {
-					throw exception;
-				}
-			});
-			return builder.parse(new InputSource(reader));
+			return builder.parse(new InputSource(new StringReader(xml)));
 		} catch (ParserConfigurationException | IOException | SAXException e) {
-            e.printStackTrace();
+			e.printStackTrace();
 			return null;
 		}
 	}

--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNTraceParser.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyTAPNTraceParser.java
@@ -44,7 +44,7 @@ public class VerifyTAPNTraceParser {
 		try {
 			StringBuilder sb = new StringBuilder();
 			String line;
-			
+
 			while ((line = reader.readLine()) != null) {
 				if (line.contains("Trace")) continue;
 				sb.append(line);
@@ -154,7 +154,6 @@ public class VerifyTAPNTraceParser {
 			int startTraceList = xml.indexOf("<trace-list>");
 			if (startTrace == -1 && startTraceList == -1) return null;
 
-			System.out.println(xml);
 			DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 			return builder.parse(new InputSource(new StringReader(xml)));
 		} catch (ParserConfigurationException | IOException | SAXException e) {

--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -4782,12 +4782,19 @@ public class QueryDialog extends JPanel {
         String rawVerificationOptions = verifytapnOptions.toString();
 
         if (verifytapnOptions.enabledOverApproximation() || verifytapnOptions.enabledUnderApproximation()) {
-            if (verifytapnOptions.kBoundPresentInRawVerificationOptions()) {
+            if (verifytapnOptions.kBoundPresentInRawVerification() && verifytapnOptions.tracePresentInRawVerification()) {
+                JOptionPane.showMessageDialog(QueryDialog.this, "Because over/under-approximation is active, the specified k-bound and trace in the custom verification options will be overwritten.", "Warning", JOptionPane.WARNING_MESSAGE);
+            } else if (verifytapnOptions.kBoundPresentInRawVerification()) {
                 JOptionPane.showMessageDialog(QueryDialog.this,
                 "Because over/under-approximation is active, the specified k-bound in the custom verification options will be overwritten.", "Warning",
                             JOptionPane.WARNING_MESSAGE);
+            } else if (verifytapnOptions.tracePresentInRawVerification()) {
+                JOptionPane.showMessageDialog(QueryDialog.this,
+                "Because over/under-approximation is active, the specified trace in the custom verification options will be overwritten.", "Warning",
+                            JOptionPane.WARNING_MESSAGE);
             }
-            rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k) +\\d+", "");
+
+            rawVerificationOptions = rawVerificationOptions.replaceAll("(--k-bound|-k|--trace|-t) +\\d*", ""); 
         }
         rawVerificationOptionsTextArea.setText(rawVerificationOptions.trim());
     }

--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -4373,6 +4373,7 @@ public class QueryDialog extends JPanel {
         noApproximationEnable.setVisible(true);
         noApproximationEnable.setSelected(true);
         noApproximationEnable.setToolTipText(TOOL_TIP_APPROXIMATION_METHOD_NONE);
+        noApproximationEnable.addActionListener(e -> updateRawVerificationOptions());
 
         overApproximationEnable = new JRadioButton("Over-approximation");
         overApproximationEnable.setVisible(true);

--- a/src/main/java/net/tapaal/gui/petrinet/verification/RunVerification.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/RunVerification.java
@@ -103,8 +103,10 @@ public class RunVerification extends RunVerificationBase {
                             TAPAALGUI.getAnimator().setTrace(result.getTrace(), traceMap);
                         }
 
-                        ColorBindingParser parser = new ColorBindingParser();
-                        parser.addBindings(result.getUnfoldedTab().getModel(), result.getRawOutput());
+                        if (result.getUnfoldedTab() != null) {
+                            ColorBindingParser parser = new ColorBindingParser();
+                            parser.addBindings(result.getUnfoldedTab().getModel(), result.getRawOutput());
+                        }
                     } else {
                         if ((
                             //XXX: this is not complete, we need a better way to signal the engine could not create a trace


### PR DESCRIPTION
Fixes:
https://bugs.launchpad.net/tapaal/+bug/2052379

Also fixes:
- Issue where gui in some cases would be unable to display trace event though the xml received from the engine was perfectly fine.
- NPE with color switches when trying to add bindings to a net that is not unfolded