### PR TITLE
Updated ids of variables in CPNs to correspond with transition names

### DIFF
--- a/src/main/resources/Example nets/cpn-packet.tapn
+++ b/src/main/resources/Example nets/cpn-packet.tapn
@@ -122,7 +122,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="Varpck"/>
+              <variable refvariable="pck"/>
             </subterm>
           </numberof>
         </structure>
@@ -251,7 +251,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="Varpck"/>
+              <variable refvariable="pck"/>
             </subterm>
           </numberof>
         </structure>
@@ -276,7 +276,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="Varpck"/>
+              <variable refvariable="pck"/>
             </subterm>
           </numberof>
         </structure>
@@ -295,7 +295,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="Varpck"/>
+              <variable refvariable="pck"/>
             </subterm>
           </numberof>
         </structure>
@@ -339,7 +339,7 @@
             <feconstant id="vpn" name="packetType"/>
           </cyclicenumeration>
         </namedsort>
-        <variabledecl id="Varpck" name="pck">
+        <variabledecl id="pck" name="pck">
           <usersort declaration="packetType"/>
         </variabledecl>
       </declarations>

--- a/src/main/resources/Example nets/philosophers.tapn
+++ b/src/main/resources/Example nets/philosophers.tapn
@@ -191,7 +191,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -210,7 +210,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -229,7 +229,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -250,7 +250,7 @@
             <subterm>
               <predecessor>
                 <subterm>
-                  <variable refvariable="varx"/>
+                  <variable refvariable="x"/>
                 </subterm>
               </predecessor>
             </subterm>
@@ -273,7 +273,7 @@
             <subterm>
               <predecessor>
                 <subterm>
-                  <variable refvariable="varx"/>
+                  <variable refvariable="x"/>
                 </subterm>
               </predecessor>
             </subterm>
@@ -294,7 +294,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -313,7 +313,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -332,7 +332,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -351,7 +351,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -372,7 +372,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -392,7 +392,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -411,7 +411,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -430,7 +430,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -449,7 +449,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varx"/>
+              <variable refvariable="x"/>
             </subterm>
           </numberof>
         </structure>
@@ -470,7 +470,7 @@
                   </numberconstant>
                 </subterm>
                 <subterm>
-                  <variable refvariable="varx"/>
+                  <variable refvariable="x"/>
                 </subterm>
               </numberof>
             </subterm>
@@ -484,7 +484,7 @@
                 <subterm>
                   <predecessor>
                     <subterm>
-                      <variable refvariable="varx"/>
+                      <variable refvariable="x"/>
                     </subterm>
                   </predecessor>
                 </subterm>
@@ -513,7 +513,7 @@
             <feconstant id="Id5" name="Philo"/>
           </cyclicenumeration>
         </namedsort>
-        <variabledecl id="varx" name="x">
+        <variabledecl id="x" name="x">
           <usersort declaration="philo"/>
         </variabledecl>
       </declarations>

--- a/src/main/resources/Example nets/referendum-colored.tapn
+++ b/src/main/resources/Example nets/referendum-colored.tapn
@@ -106,7 +106,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varv"/>
+              <variable refvariable="v"/>
             </subterm>
           </numberof>
         </structure>
@@ -125,7 +125,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varv"/>
+              <variable refvariable="v"/>
             </subterm>
           </numberof>
         </structure>
@@ -144,7 +144,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varv"/>
+              <variable refvariable="v"/>
             </subterm>
           </numberof>
         </structure>
@@ -163,7 +163,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varv"/>
+              <variable refvariable="v"/>
             </subterm>
           </numberof>
         </structure>
@@ -192,7 +192,7 @@
             <feconstant id="Voters10" name="Voters"/>
           </cyclicenumeration>
         </namedsort>
-        <variabledecl id="varv" name="v">
+        <variabledecl id="v" name="v">
           <usersort declaration="Voters"/>
         </variabledecl>
       </declarations>

--- a/src/main/resources/Example nets/referendum-timed-colored.tapn
+++ b/src/main/resources/Example nets/referendum-timed-colored.tapn
@@ -112,7 +112,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varv"/>
+              <variable refvariable="v"/>
             </subterm>
           </numberof>
         </structure>
@@ -137,7 +137,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varv"/>
+              <variable refvariable="v"/>
             </subterm>
           </numberof>
         </structure>
@@ -156,7 +156,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varv"/>
+              <variable refvariable="v"/>
             </subterm>
           </numberof>
         </structure>
@@ -181,7 +181,7 @@
               </numberconstant>
             </subterm>
             <subterm>
-              <variable refvariable="varv"/>
+              <variable refvariable="v"/>
             </subterm>
           </numberof>
         </structure>
@@ -210,7 +210,7 @@
             <feconstant id="Voters10" name="Voters"/>
           </cyclicenumeration>
         </namedsort>
-        <variabledecl id="varv" name="v">
+        <variabledecl id="v" name="v">
           <usersort declaration="Voters"/>
         </variabledecl>
       </declarations>

--- a/src/main/resources/Example nets/token-ring.tapn
+++ b/src/main/resources/Example nets/token-ring.tapn
@@ -139,7 +139,7 @@
             <subterm>
               <inequality>
                 <subterm>
-                  <variable refvariable="vari"/>
+                  <variable refvariable="i"/>
                 </subterm>
                 <subterm>
                   <useroperator declaration="process0"/>
@@ -149,10 +149,10 @@
             <subterm>
               <inequality>
                 <subterm>
-                  <variable refvariable="varx"/>
+                  <variable refvariable="x"/>
                 </subterm>
                 <subterm>
-                  <variable refvariable="vary"/>
+                  <variable refvariable="y"/>
                 </subterm>
               </inequality>
             </subterm>
@@ -180,7 +180,7 @@
                     <subterm>
                       <successor>
                         <subterm>
-                          <variable refvariable="varx"/>
+                          <variable refvariable="x"/>
                         </subterm>
                       </successor>
                     </subterm>
@@ -201,7 +201,7 @@
                       <useroperator declaration="process5"/>
                     </subterm>
                     <subterm>
-                      <variable refvariable="varx"/>
+                      <variable refvariable="x"/>
                     </subterm>
                   </tuple>
                 </subterm>
@@ -232,7 +232,7 @@
                       <useroperator declaration="process0"/>
                     </subterm>
                     <subterm>
-                      <variable refvariable="varx"/>
+                      <variable refvariable="x"/>
                     </subterm>
                   </tuple>
                 </subterm>
@@ -251,7 +251,7 @@
                       <useroperator declaration="process5"/>
                     </subterm>
                     <subterm>
-                      <variable refvariable="varx"/>
+                      <variable refvariable="x"/>
                     </subterm>
                   </tuple>
                 </subterm>
@@ -279,10 +279,10 @@
                 <subterm>
                   <tuple>
                     <subterm>
-                      <variable refvariable="vari"/>
+                      <variable refvariable="i"/>
                     </subterm>
                     <subterm>
-                      <variable refvariable="vary"/>
+                      <variable refvariable="y"/>
                     </subterm>
                   </tuple>
                 </subterm>
@@ -300,12 +300,12 @@
                     <subterm>
                       <predecessor>
                         <subterm>
-                          <variable refvariable="vari"/>
+                          <variable refvariable="i"/>
                         </subterm>
                       </predecessor>
                     </subterm>
                     <subterm>
-                      <variable refvariable="vary"/>
+                      <variable refvariable="y"/>
                     </subterm>
                   </tuple>
                 </subterm>
@@ -333,10 +333,10 @@
                 <subterm>
                   <tuple>
                     <subterm>
-                      <variable refvariable="vari"/>
+                      <variable refvariable="i"/>
                     </subterm>
                     <subterm>
-                      <variable refvariable="varx"/>
+                      <variable refvariable="x"/>
                     </subterm>
                   </tuple>
                 </subterm>
@@ -354,12 +354,12 @@
                     <subterm>
                       <predecessor>
                         <subterm>
-                          <variable refvariable="vari"/>
+                          <variable refvariable="i"/>
                         </subterm>
                       </predecessor>
                     </subterm>
                     <subterm>
-                      <variable refvariable="vary"/>
+                      <variable refvariable="y"/>
                     </subterm>
                   </tuple>
                 </subterm>
@@ -395,13 +395,13 @@
             <usersort declaration="process"/>
           </productsort>
         </namedsort>
-        <variabledecl id="vari" name="i">
+        <variabledecl id="i" name="i">
           <usersort declaration="process"/>
         </variabledecl>
-        <variabledecl id="varx" name="x">
+        <variabledecl id="x" name="x">
           <usersort declaration="process"/>
         </variabledecl>
-        <variabledecl id="vary" name="y">
+        <variabledecl id="y" name="y">
           <usersort declaration="process"/>
         </variabledecl>
       </declarations>


### PR DESCRIPTION
fixed all CPN examples so that ids of variables are equal to the variable names