### PR TITLE
Fixed saving of approximation setting in queries using EG or AF for timed nets

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -1757,10 +1757,8 @@ public class QueryDialog extends JPanel {
             existsDiamond.setSelected(true);
         } else if (queryToCreateFrom.getProperty() instanceof TCTLEGNode) {
             existsBox.setSelected(true);
-            noApproximationEnable.setSelected(true);
         } else if (queryToCreateFrom.getProperty() instanceof TCTLAFNode) {
             forAllDiamond.setSelected(true);
-            noApproximationEnable.setSelected(true);
         } else if (queryToCreateFrom.getProperty() instanceof TCTLAGNode) {
             forAllBox.setSelected(true);
         }


### PR DESCRIPTION
Fixed problems with saving selected approximation button when saving a query using a EG or AF quantifier for timed networks.