### PR TITLE
Fixed color type not updating correctly

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AllExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AllExpression.java
@@ -138,9 +138,6 @@ public class AllExpression extends ColorExpression {
 
     @Override
     public ColorExpression getExprWithNewColorType(ColorType ct) {
-        if (sort.getName().equals(ct.getName())) {
-            return new AllExpression(ct);
-        }
-        return deepCopy();
+        return new AllExpression(ct);
     }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
@@ -182,7 +182,7 @@ public class NumberOfExpression extends ArcExpression {
         Vector<ColorExpression> colorExpressions = new Vector<>();
         ColorExpression colorExpression = color.get(0);
 
-        if (colorExpression.colorType == null || colorExpression.colorType.getName().equals(ct.getName()) || colorInColorType(colorExpression, ct)) {
+        if (colorExpression instanceof AllExpression || colorExpression.colorType == null || colorExpression.colorType.getName().equals(ct.getName()) || colorInColorType(colorExpression, ct)) {
             colorExpressions.add(colorExpression.getExprWithNewColorType(ct));
         } else {
             colorExpressions.add(colorExpression);


### PR DESCRIPTION
Fixed problem with color type for .all expressions not being updated correctly

To reproduce:
open colored referrendum and edit the color type, then save and load.