### PR TITLE
Fixed glitched places having a .all initial marking

### DIFF
--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/AddExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/AddExpression.java
@@ -206,4 +206,13 @@ public class AddExpression extends ArcExpression {
         }
         return new AddExpression(arcExpressions);
     }
+
+    @Override
+    public ArcExpression getExprConverted(ColorType oldCt, ColorType newCt) {
+        Vector<ArcExpression> arcExpressions = new Vector<>();
+        for (ArcExpression expr : constituents) {
+            arcExpressions.add(expr.getExprConverted(oldCt, newCt));
+        }
+        return new AddExpression(arcExpressions);
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/ArcExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/ArcExpression.java
@@ -37,4 +37,6 @@ public abstract class ArcExpression extends Expression {
     public abstract Integer weight();
 
     public abstract ArcExpression getExprWithNewColorType(ColorType ct);
+
+    public abstract ArcExpression getExprConverted(ColorType oldCt, ColorType newCt);
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
@@ -190,6 +190,19 @@ public class NumberOfExpression extends ArcExpression {
         return new NumberOfExpression(number, colorExpressions);
     }
 
+    @Override
+    public ArcExpression getExprConverted(ColorType oldCt, ColorType newCt) {
+        Vector<ColorExpression> colorExpressions = new Vector<>();
+        ColorExpression colorExpression = color.get(0);
+
+        if (colorExpression.colorType == null || colorExpression.colorType.getName().equals(oldCt.getName()) || colorInColorType(colorExpression, oldCt)) {
+            colorExpressions.add(colorExpression.getExprWithNewColorType(newCt));
+        } else {
+            colorExpressions.add(colorExpression);
+        }
+        return new NumberOfExpression(number, colorExpressions);
+    }
+
     private boolean colorInColorType(ColorExpression colorExpression, ColorType colorType) {
         for (Color c : colorType.getColors()) {
             if (colorExpression.containsColor(c)) {

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/NumberOfExpression.java
@@ -182,7 +182,7 @@ public class NumberOfExpression extends ArcExpression {
         Vector<ColorExpression> colorExpressions = new Vector<>();
         ColorExpression colorExpression = color.get(0);
 
-        if (colorExpression instanceof AllExpression || colorExpression.colorType == null || colorExpression.colorType.getName().equals(ct.getName()) || colorInColorType(colorExpression, ct)) {
+        if (colorExpression.colorType == null || colorExpression.colorType.getName().equals(ct.getName()) || colorInColorType(colorExpression, ct)) {
             colorExpressions.add(colorExpression.getExprWithNewColorType(ct));
         } else {
             colorExpressions.add(colorExpression);

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderArcExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/PlaceHolderArcExpression.java
@@ -79,4 +79,9 @@ public class PlaceHolderArcExpression extends ArcExpression implements PlaceHold
     public ArcExpression getExprWithNewColorType(ColorType ct) {
         return deepCopy();
     }
+
+    @Override
+    public ArcExpression getExprConverted(ColorType oldCt, ColorType newCt) {
+        return deepCopy();
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/ScalarProductExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/ScalarProductExpression.java
@@ -117,4 +117,9 @@ public class ScalarProductExpression extends ArcExpression {
     public ArcExpression getExprWithNewColorType(ColorType ct) {
         return new ScalarProductExpression(scalar, expr.getExprWithNewColorType(ct));
     }
+
+    @Override
+    public ArcExpression getExprConverted(ColorType oldCt, ColorType newCt) {
+        return new ScalarProductExpression(scalar, expr.getExprConverted(oldCt, newCt));
+    }
 }

--- a/src/main/java/dk/aau/cs/model/CPN/Expressions/SubtractExpression.java
+++ b/src/main/java/dk/aau/cs/model/CPN/Expressions/SubtractExpression.java
@@ -140,4 +140,9 @@ public class SubtractExpression extends ArcExpression {
     public ArcExpression getExprWithNewColorType(ColorType ct) {
         return new SubtractExpression(left.getExprWithNewColorType(ct), right.getExprWithNewColorType(ct));
     }
+
+    @Override
+    public ArcExpression getExprConverted(ColorType oldCt, ColorType newCt) {
+        return new SubtractExpression(left.getExprConverted(oldCt, newCt), right.getExprConverted(oldCt, newCt));
+    }
 }

--- a/src/main/java/net/tapaal/gui/petrinet/undo/Colored/UpdateColorTypeCommand.java
+++ b/src/main/java/net/tapaal/gui/petrinet/undo/Colored/UpdateColorTypeCommand.java
@@ -73,7 +73,8 @@ public class UpdateColorTypeCommand implements Command {
             for (TimedPlace place : tapn.places()) {
                 if (place.getColorType().equals(oldColorType)) {
 
-                    place.setTokenExpression(place.getTokensAsExpression().getExprConverted(oldColorType, newColorType));
+                    if(place.getTokensAsExpression() != null)
+                        place.setTokenExpression(place.getTokensAsExpression().getExprConverted(oldColorType, newColorType));
 
                     List<TimedToken> oldTokens = new ArrayList<>(place.tokens());
                     place.setColorType(newColorType);

--- a/src/main/java/net/tapaal/gui/petrinet/undo/Colored/UpdateColorTypeCommand.java
+++ b/src/main/java/net/tapaal/gui/petrinet/undo/Colored/UpdateColorTypeCommand.java
@@ -1,7 +1,7 @@
 package net.tapaal.gui.petrinet.undo.Colored;
 
 import dk.aau.cs.model.CPN.*;
-import dk.aau.cs.model.CPN.Expressions.ArcExpression;
+import dk.aau.cs.model.CPN.Expressions.*;
 import net.tapaal.gui.petrinet.undo.Command;
 import dk.aau.cs.model.tapn.*;
 import net.tapaal.gui.petrinet.editor.ConstantsPane;
@@ -72,6 +72,9 @@ public class UpdateColorTypeCommand implements Command {
         for (TimedArcPetriNet tapn : network.allTemplates()) {
             for (TimedPlace place : tapn.places()) {
                 if (place.getColorType().equals(oldColorType)) {
+
+                    place.setTokenExpression(place.getTokensAsExpression().getExprConverted(oldColorType, newColorType));
+
                     List<TimedToken> oldTokens = new ArrayList<>(place.tokens());
                     place.setColorType(newColorType);
                     for (TimedToken token : oldTokens) {
@@ -83,12 +86,12 @@ public class UpdateColorTypeCommand implements Command {
             }
             for (TimedInputArc arc : tapn.inputArcs()) {
                 if (arc.getArcExpression() != null) {
-                    arc.setExpression(arc.getArcExpression().getExprWithNewColorType(newColorType));
+                    arc.setExpression(arc.getArcExpression().getExprConverted(oldColorType, newColorType));
                 }
             }
             for (TimedOutputArc arc : tapn.outputArcs()) {
                 if (arc.getExpression() != null) {
-                    arc.setExpression(arc.getExpression().getExprWithNewColorType(newColorType));
+                    arc.setExpression(arc.getExpression().getExprConverted(oldColorType, newColorType));
                 }
             }
             for (TimedTransition transition : tapn.transitions()) {


### PR DESCRIPTION
After the PR https://github.com/TAPAAL/tapaal-gui/pull/159 that was made to fix a bug on arcs, a new bug was introduced (described in https://bugs.launchpad.net/tapaal/+bug/2080817).

It seems that reversing one of the changes of the PR fixes the new bug while keeping the first fixed