### PR TITLE
UI bugs for SMC transitions

### DIFF
--- a/src/main/java/dk/aau/cs/model/tapn/DoubleProbability.java
+++ b/src/main/java/dk/aau/cs/model/tapn/DoubleProbability.java
@@ -19,7 +19,9 @@ public class DoubleProbability extends Probability {
     }
 
     @Override
-    public String toString() {
+    public String toString()
+    {
+        if(isInfinite()) return "∞";
         return String.valueOf(value);
     }
 

--- a/src/main/java/dk/aau/cs/model/tapn/DoubleProbability.java
+++ b/src/main/java/dk/aau/cs/model/tapn/DoubleProbability.java
@@ -30,7 +30,7 @@ public class DoubleProbability extends Probability {
     }
 
     public String nameForSaving(boolean writeConstantNames){
-        return Double.toString(value);
+        return Double.isInfinite(value) ? "inf" : Double.toString(value);
     }
 }
 

--- a/src/main/java/dk/aau/cs/model/tapn/Probability.java
+++ b/src/main/java/dk/aau/cs/model/tapn/Probability.java
@@ -6,6 +6,10 @@ public abstract class Probability {
     public abstract String toString(boolean displayConstantnames);
     public abstract String nameForSaving(boolean writeConstantNames);
 
+    public boolean isInfinite() {
+        return Double.isInfinite(value());
+    }
+
     public static Probability parseProbability(String attribute, ConstantStore constants) {
         Probability weight;
         try{

--- a/src/main/java/dk/aau/cs/model/tapn/Probability.java
+++ b/src/main/java/dk/aau/cs/model/tapn/Probability.java
@@ -12,6 +12,7 @@ public abstract class Probability {
 
     public static Probability parseProbability(String attribute, ConstantStore constants) {
         Probability weight;
+        if(attribute.equals("inf")) return new DoubleProbability(Double.POSITIVE_INFINITY);
         try{
             double weightAsDouble = Double.parseDouble(attribute);
             weight = new DoubleProbability(weightAsDouble);

--- a/src/main/java/net/tapaal/gui/petrinet/editor/DistributionPanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/DistributionPanel.java
@@ -140,6 +140,23 @@ public class DistributionPanel extends JPanel {
         gbc.gridx++;
         gbc.anchor = GridBagConstraints.EAST;
         add(distributionShowGraph, gbc);
+
+        setUrgent(transition.underlyingTransition().isUrgent());
+    }
+
+    public void setUrgent(boolean urgent) {
+        if(urgent) {
+            displayDistributionFields(SMCDistribution.urgent());
+            distributionType.setEnabled(false);
+            useDiscreteDistribution.setEnabled(false);
+            useContinuousDistribution.setEnabled(false);
+            distributionParam1Field.setEnabled(false);
+        } else {
+            distributionType.setEnabled(true);
+            useDiscreteDistribution.setEnabled(true);
+            useContinuousDistribution.setEnabled(true);
+            distributionParam1Field.setEnabled(true);
+        }
     }
 
     public SMCDistribution parseDistribution() {

--- a/src/main/java/pipe/gui/petrinet/editor/TAPNTransitionEditor.java
+++ b/src/main/java/pipe/gui/petrinet/editor/TAPNTransitionEditor.java
@@ -64,7 +64,7 @@ public class TAPNTransitionEditor extends JPanel {
 	    if(!transition.isColored() || !coloredTransitionGuardPanel.showGuardPanel()){
 	        coloredTransitionGuardPanel.setVisible(false);
         }
-        distributionPanel.setVisible((!urgentCheckBox.isSelected()) && transition.isStochastic());
+        distributionPanel.setVisible(transition.isStochastic());
     }
 
 	private void initComponents() {
@@ -189,8 +189,7 @@ public class TAPNTransitionEditor extends JPanel {
 			if(!isUrgencyOK()){
 				urgentCheckBox.setSelected(false);
 			}
-            distributionPanel.setVisible((!urgentCheckBox.isSelected()) && transition.isStochastic());
-            dialog.pack();
+            distributionPanel.setUrgent(urgentCheckBox.isSelected());
 		});
 
         gridBagConstraints = new java.awt.GridBagConstraints();

--- a/src/main/java/pipe/gui/petrinet/graphicElements/tapn/TimedTransitionComponent.java
+++ b/src/main/java/pipe/gui/petrinet/graphicElements/tapn/TimedTransitionComponent.java
@@ -207,7 +207,7 @@ public class TimedTransitionComponent extends Transition {
 	
 	@Override
 	public void update(boolean displayConstantNames) {
-        getNameLabel().setText("");
+        super.update(displayConstantNames);
 		if(transition != null) {
 			getNameLabel().setName(transition.name());
 			getNameLabel().setVisible(attributesVisible);
@@ -225,8 +225,7 @@ public class TimedTransitionComponent extends Transition {
                     )
                 );
             }
-			if(underlyingTransition().getGuard() != null && lens.isColored()){
-                super.update(displayConstantNames);
+			if(underlyingTransition().getGuard() != null && lens.isColored()) {
                 pnName.setText(pnName.getText() + "\n" + buildGuardString(this.underlyingTransition().getGuard().toString()));
             }
 		}

--- a/src/main/resources/Example nets/euler-number.tapn
+++ b/src/main/resources/Example nets/euler-number.tapn
@@ -10,7 +10,7 @@
     </structure>
   </declaration>
   <net active="true" id="Euler" type="P/T net">
-    <labels border="true" height="196" positionX="390" positionY="240" width="312">This simple stochastic Petri net uniformly samples delays between 0 and 1 and because of the transport arcs that do not reset the age of the token, the age of the token in "accumulated_time" represents the global time that has passed so far. As soon as this age reaches 1, the "timeout" transition fires.
+    <labels border="true" height="270" positionX="390" positionY="240" width="313">This simple stochastic Petri net uniformly samples delays between 0 and 1 and because of the transport arcs that do not reset the age of the token, the age of the token in "accumulated_time" represents the global time that has passed so far. As soon as this age reaches 1, the "timeout" transition fires.
 
 The query asks for the probability of placing a token to the place "finished" and it clearly converges to 1. 
 
@@ -50,8 +50,8 @@ The average number of steps before the place "finished" is marked converges to t
         </structure>
       </type>
     </place>
-    <transition a="0.0" angle="0" b="1.0" displayName="true" distribution="uniform" firingMode="Oldest" id="delay" infiniteServer="false" name="delay" nameOffsetX="56" nameOffsetY="50" player="0" positionX="240" positionY="300" priority="0" urgent="false" weight="1.0"/>
-    <transition angle="0" displayName="true" distribution="constant" firingMode="Oldest" id="timeout" infiniteServer="false" name="timeout" nameOffsetX="53" nameOffsetY="-21" player="0" positionX="390" positionY="150" priority="0" urgent="false" value="0.0" weight="1.0"/>
+    <transition a="0.0" angle="0" b="1.0" displayName="true" distribution="uniform" firingMode="Random" id="delay" infiniteServer="false" name="delay" nameOffsetX="56" nameOffsetY="50" player="0" positionX="240" positionY="300" priority="0" urgent="false" weight="1.0"/>
+    <transition angle="0" displayName="true" distribution="constant" firingMode="Random" id="timeout" infiniteServer="false" name="timeout" nameOffsetX="66" nameOffsetY="-33" player="0" positionX="390" positionY="150" priority="0" urgent="false" value="0.0" weight="1.0"/>
     <arc id="A1" inscription="[0,inf):1" nameOffsetX="0" nameOffsetY="0" source="accumulated_time" target="delay" transportID="1" type="transport" weight="1">
       <hlinscription>
         <text>1'dot</text>
@@ -71,7 +71,7 @@ The average number of steps before the place "finished" is marked converges to t
       <arcpath arcPointType="false" id="0" xCoord="244" yCoord="175"/>
       <arcpath arcPointType="false" id="1" xCoord="210" yCoord="210"/>
       <arcpath arcPointType="true" id="2" xCoord="210" yCoord="270"/>
-      <arcpath arcPointType="false" id="3" xCoord="249" yCoord="315"/>
+      <arcpath arcPointType="false" id="3" xCoord="250" yCoord="315"/>
     </arc>
     <arc id="A0" inscription="[0,inf):1" nameOffsetX="0" nameOffsetY="0" source="delay" target="accumulated_time" transportID="1" type="transport" weight="1">
       <hlinscription>
@@ -89,7 +89,7 @@ The average number of steps before the place "finished" is marked converges to t
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="259" yCoord="315"/>
+      <arcpath arcPointType="false" id="0" xCoord="260" yCoord="315"/>
       <arcpath arcPointType="false" id="1" xCoord="300" yCoord="270"/>
       <arcpath arcPointType="true" id="2" xCoord="300" yCoord="210"/>
       <arcpath arcPointType="false" id="3" xCoord="265" yCoord="175"/>
@@ -111,7 +111,7 @@ The average number of steps before the place "finished" is marked converges to t
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="270" yCoord="165"/>
-      <arcpath arcPointType="false" id="1" xCoord="399" yCoord="165"/>
+      <arcpath arcPointType="false" id="1" xCoord="400" yCoord="165"/>
     </arc>
     <arc id="A3" inscription="1" nameOffsetX="0" nameOffsetY="0" source="timeout" target="finished" type="normal" weight="1">
       <hlinscription>
@@ -129,7 +129,7 @@ The average number of steps before the place "finished" is marked converges to t
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="409" yCoord="165"/>
+      <arcpath arcPointType="false" id="0" xCoord="410" yCoord="165"/>
       <arcpath arcPointType="false" id="1" xCoord="555" yCoord="165"/>
     </arc>
   </net>

--- a/src/main/resources/Example nets/fair-coin-from-unfair.tapn
+++ b/src/main/resources/Example nets/fair-coin-from-unfair.tapn
@@ -89,11 +89,11 @@
         </structure>
       </type>
     </place>
-    <transition angle="0" displayName="true" distribution="constant" firingMode="Oldest" id="inconclusive" infiniteServer="false" name="inconclusive" nameOffsetX="0" nameOffsetY="0" player="0" positionX="300" positionY="180" priority="0" urgent="false" value="1.0" weight="1.0"/>
-    <transition angle="0" displayName="true" distribution="constant" firingMode="Oldest" id="head" infiniteServer="false" name="head" nameOffsetX="3" nameOffsetY="2" player="0" positionX="465" positionY="180" priority="0" urgent="true" value="0.0" weight="headprob"/>
-    <transition angle="0" displayName="true" distribution="constant" firingMode="Oldest" id="tail" infiniteServer="false" name="tail" nameOffsetX="8" nameOffsetY="8" player="0" positionX="615" positionY="180" priority="0" urgent="true" value="0.0" weight="tailprob"/>
-    <transition angle="0" displayName="true" distribution="constant" firingMode="Oldest" id="choosing_heads" infiniteServer="false" name="choosing_heads" nameOffsetX="-20" nameOffsetY="12" player="0" positionX="300" positionY="345" priority="0" urgent="true" value="0.0" weight="1.0"/>
-    <transition angle="0" displayName="true" distribution="constant" firingMode="Oldest" id="choosing_tails" infiniteServer="false" name="choosing_tails" nameOffsetX="116" nameOffsetY="11" player="0" positionX="795" positionY="345" priority="0" urgent="true" value="0.0" weight="1.0"/>
+    <transition angle="0" displayName="true" distribution="constant" firingMode="Random" id="inconclusive" infiniteServer="false" name="inconclusive" nameOffsetX="0" nameOffsetY="0" player="0" positionX="300" positionY="180" priority="0" urgent="false" value="1.0" weight="1.0"/>
+    <transition angle="0" displayName="true" distribution="constant" firingMode="Random" id="head" infiniteServer="false" name="head" nameOffsetX="3" nameOffsetY="2" player="0" positionX="465" positionY="180" priority="0" urgent="true" value="0.0" weight="headprob"/>
+    <transition angle="0" displayName="true" distribution="constant" firingMode="Random" id="tail" infiniteServer="false" name="tail" nameOffsetX="8" nameOffsetY="8" player="0" positionX="615" positionY="180" priority="0" urgent="true" value="0.0" weight="tailprob"/>
+    <transition angle="0" displayName="true" distribution="constant" firingMode="Random" id="choosing_heads" infiniteServer="false" name="choosing_heads" nameOffsetX="-20" nameOffsetY="12" player="0" positionX="300" positionY="345" priority="0" urgent="true" value="0.0" weight="1.0"/>
+    <transition angle="0" displayName="true" distribution="constant" firingMode="Random" id="choosing_tails" infiniteServer="false" name="choosing_tails" nameOffsetX="116" nameOffsetY="11" player="0" positionX="795" positionY="345" priority="0" urgent="true" value="0.0" weight="1.0"/>
     <arc id="A0" inscription="[0,inf)" nameOffsetX="-37" nameOffsetY="-7" source="tossed" target="inconclusive" type="timed" weight="1">
       <hlinscription>
         <text>1'(coins.all, t)</text>
@@ -119,8 +119,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="542" yCoord="351"/>
-      <arcpath arcPointType="false" id="1" xCoord="319" yCoord="200"/>
+      <arcpath arcPointType="false" id="0" xCoord="543" yCoord="352"/>
+      <arcpath arcPointType="false" id="1" xCoord="320" yCoord="200"/>
     </arc>
     <arc id="A1" inscription="1" nameOffsetX="-49" nameOffsetY="-3" source="inconclusive" target="ready_to_toss" type="normal" weight="1">
       <hlinscription>
@@ -141,7 +141,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="320" yCoord="190"/>
-      <arcpath arcPointType="false" id="1" xCoord="542" yCoord="52"/>
+      <arcpath arcPointType="false" id="1" xCoord="542" yCoord="53"/>
     </arc>
     <arc id="A2" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="ready_to_toss" target="head" type="timed" weight="1">
       <hlinscription>
@@ -159,8 +159,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="547" yCoord="58"/>
-      <arcpath arcPointType="false" id="1" xCoord="479" yCoord="179"/>
+      <arcpath arcPointType="false" id="0" xCoord="548" yCoord="58"/>
+      <arcpath arcPointType="false" id="1" xCoord="480" yCoord="180"/>
     </arc>
     <arc id="A3" inscription="1" nameOffsetX="-21" nameOffsetY="-22" source="head" target="tossed" type="normal" weight="1">
       <hlinscription>
@@ -186,7 +186,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="480" yCoord="210"/>
-      <arcpath arcPointType="false" id="1" xCoord="548" yCoord="346"/>
+      <arcpath arcPointType="false" id="1" xCoord="548" yCoord="347"/>
     </arc>
     <arc id="A4" inscription="[0,inf)" nameOffsetX="39" nameOffsetY="0" source="ready_to_toss" target="tail" type="timed" weight="1">
       <hlinscription>
@@ -205,7 +205,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="562" yCoord="58"/>
-      <arcpath arcPointType="false" id="1" xCoord="629" yCoord="179"/>
+      <arcpath arcPointType="false" id="1" xCoord="630" yCoord="180"/>
     </arc>
     <arc id="A5" inscription="1" nameOffsetX="61" nameOffsetY="-19" source="tail" target="tossed" type="normal" weight="1">
       <hlinscription>
@@ -231,7 +231,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="630" yCoord="210"/>
-      <arcpath arcPointType="false" id="1" xCoord="561" yCoord="346"/>
+      <arcpath arcPointType="false" id="1" xCoord="562" yCoord="347"/>
     </arc>
     <arc id="A6" inscription="[0,inf)" nameOffsetX="69" nameOffsetY="10" source="tossed" target="choosing_heads" type="timed" weight="1">
       <hlinscription>
@@ -280,7 +280,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="540" yCoord="360"/>
-      <arcpath arcPointType="false" id="1" xCoord="319" yCoord="360"/>
+      <arcpath arcPointType="false" id="1" xCoord="320" yCoord="360"/>
     </arc>
     <arc id="A7" inscription="1" nameOffsetX="0" nameOffsetY="0" source="choosing_heads" target="heads" type="normal" weight="1">
       <hlinscription>
@@ -348,7 +348,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="570" yCoord="360"/>
-      <arcpath arcPointType="false" id="1" xCoord="804" yCoord="360"/>
+      <arcpath arcPointType="false" id="1" xCoord="805" yCoord="361"/>
     </arc>
     <arc id="A9" inscription="1" nameOffsetX="0" nameOffsetY="0" source="choosing_tails" target="tails" type="normal" weight="1">
       <hlinscription>

--- a/src/main/resources/Example nets/fireflies.tapn
+++ b/src/main/resources/Example nets/fireflies.tapn
@@ -72,11 +72,11 @@
         </structure>
       </type>
     </place>
-    <transition a="0.0" angle="0" b="2.0" displayName="true" distribution="uniform" firingMode="Oldest" id="arrive" infiniteServer="false" name="arrive" nameOffsetX="55" nameOffsetY="-26" player="0" positionX="270" positionY="165" priority="0" urgent="false" weight="1.0"/>
-    <transition angle="0" displayName="true" distribution="normal" firingMode="Oldest" id="ready" infiniteServer="false" mean="0.5" name="ready" nameOffsetX="0" nameOffsetY="0" player="0" positionX="525" positionY="90" priority="0" stddev="0.1" urgent="false" weight="1.0"/>
-    <transition angle="0" displayName="true" distribution="exponential" firingMode="Oldest" id="fire_alone" infiniteServer="false" name="fire_alone" nameOffsetX="104" nameOffsetY="-26" player="0" positionX="735" positionY="60" priority="0" rate="0.1" urgent="false" weight="1.0"/>
-    <transition angle="0" displayName="true" distribution="constant" firingMode="Oldest" id="fire_jointly" infiniteServer="false" name="fire_jointly" nameOffsetX="66" nameOffsetY="55" player="0" positionX="630" positionY="255" priority="0" urgent="true" value="0.0" weight="1.0"/>
-    <transition angle="0" displayName="true" distribution="constant" firingMode="Oldest" id="all_fired" infiniteServer="false" name="all_fired" nameOffsetX="45" nameOffsetY="-11" player="0" positionX="750" positionY="165" priority="0" urgent="true" value="0.0" weight="1.0"/>
+    <transition a="0.0" angle="0" b="2.0" displayName="true" distribution="uniform" firingMode="Random" id="arrive" infiniteServer="false" name="arrive" nameOffsetX="55" nameOffsetY="-26" player="0" positionX="270" positionY="165" priority="0" urgent="false" weight="1.0"/>
+    <transition angle="0" displayName="true" distribution="normal" firingMode="Random" id="ready" infiniteServer="false" mean="0.5" name="ready" nameOffsetX="0" nameOffsetY="0" player="0" positionX="525" positionY="90" priority="0" stddev="0.1" urgent="false" weight="1.0"/>
+    <transition angle="0" displayName="true" distribution="exponential" firingMode="Random" id="fire_alone" infiniteServer="false" name="fire_alone" nameOffsetX="126" nameOffsetY="-20" player="0" positionX="735" positionY="60" priority="0" rate="0.1" urgent="false" weight="1.0"/>
+    <transition angle="0" displayName="true" distribution="constant" firingMode="Random" id="fire_jointly" infiniteServer="false" name="fire_jointly" nameOffsetX="66" nameOffsetY="55" player="0" positionX="630" positionY="255" priority="0" urgent="true" value="0.0" weight="1.0"/>
+    <transition angle="0" displayName="true" distribution="constant" firingMode="Random" id="all_fired" infiniteServer="false" name="all_fired" nameOffsetX="50" nameOffsetY="-21" player="0" positionX="750" positionY="165" priority="0" urgent="true" value="0.0" weight="1.0"/>
     <arc id="A0" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="waiting" target="arrive" type="timed" weight="1">
       <hlinscription>
         <text>1'x</text>
@@ -94,7 +94,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="165" yCoord="180"/>
-      <arcpath arcPointType="false" id="1" xCoord="279" yCoord="180"/>
+      <arcpath arcPointType="false" id="1" xCoord="280" yCoord="181"/>
     </arc>
     <arc id="A1" inscription="1" nameOffsetX="0" nameOffsetY="0" source="arrive" target="charging" type="normal" weight="1">
       <hlinscription>
@@ -112,7 +112,7 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="289" yCoord="180"/>
+      <arcpath arcPointType="false" id="0" xCoord="290" yCoord="180"/>
       <arcpath arcPointType="false" id="1" xCoord="390" yCoord="180"/>
     </arc>
     <arc id="A2" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="charging" target="ready" type="timed" weight="1">
@@ -131,8 +131,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="417" yCoord="172"/>
-      <arcpath arcPointType="false" id="1" xCoord="534" yCoord="105"/>
+      <arcpath arcPointType="false" id="0" xCoord="418" yCoord="173"/>
+      <arcpath arcPointType="false" id="1" xCoord="535" yCoord="106"/>
     </arc>
     <arc id="A3" inscription="1" nameOffsetX="0" nameOffsetY="0" source="ready" target="charged" type="normal" weight="1">
       <hlinscription>
@@ -150,8 +150,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="544" yCoord="105"/>
-      <arcpath arcPointType="false" id="1" xCoord="632" yCoord="171"/>
+      <arcpath arcPointType="false" id="0" xCoord="545" yCoord="105"/>
+      <arcpath arcPointType="false" id="1" xCoord="633" yCoord="171"/>
     </arc>
     <arc id="A4" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="charged" target="fire_alone" type="timed" weight="1">
       <hlinscription>
@@ -169,8 +169,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="655" yCoord="169"/>
-      <arcpath arcPointType="false" id="1" xCoord="744" yCoord="75"/>
+      <arcpath arcPointType="false" id="0" xCoord="655" yCoord="170"/>
+      <arcpath arcPointType="false" id="1" xCoord="745" yCoord="76"/>
     </arc>
     <arc id="A9" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="charged" target="fire_jointly" type="timed" weight="1">
       <hlinscription>
@@ -188,8 +188,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="644" yCoord="194"/>
-      <arcpath arcPointType="false" id="1" xCoord="644" yCoord="254"/>
+      <arcpath arcPointType="false" id="0" xCoord="645" yCoord="195"/>
+      <arcpath arcPointType="false" id="1" xCoord="645" yCoord="255"/>
     </arc>
     <arc id="A6" inscription="1" nameOffsetX="0" nameOffsetY="0" source="fire_alone" target="firing" type="normal" weight="1">
       <hlinscription>
@@ -207,8 +207,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="754" yCoord="80"/>
-      <arcpath arcPointType="false" id="1" xCoord="873" yCoord="170"/>
+      <arcpath arcPointType="false" id="0" xCoord="755" yCoord="80"/>
+      <arcpath arcPointType="false" id="1" xCoord="873" yCoord="171"/>
     </arc>
     <arc id="A7" inscription="1" nameOffsetX="0" nameOffsetY="0" source="fire_alone" target="charging" type="normal" weight="1">
       <hlinscription>
@@ -226,7 +226,7 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="749" yCoord="59"/>
+      <arcpath arcPointType="false" id="0" xCoord="750" yCoord="60"/>
       <arcpath arcPointType="false" id="1" xCoord="750" yCoord="30"/>
       <arcpath arcPointType="false" id="2" xCoord="405" yCoord="30"/>
       <arcpath arcPointType="false" id="3" xCoord="405" yCoord="165"/>
@@ -247,9 +247,9 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="879" yCoord="193"/>
+      <arcpath arcPointType="false" id="0" xCoord="880" yCoord="194"/>
       <arcpath arcPointType="true" id="1" xCoord="810" yCoord="270"/>
-      <arcpath arcPointType="false" id="2" xCoord="649" yCoord="275"/>
+      <arcpath arcPointType="false" id="2" xCoord="650" yCoord="276"/>
     </arc>
     <arc id="A10" inscription="1" nameOffsetX="0" nameOffsetY="0" source="fire_jointly" target="firing" type="normal" weight="1">
       <hlinscription>
@@ -267,8 +267,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="650" yCoord="265"/>
-      <arcpath arcPointType="false" id="1" xCoord="870" yCoord="185"/>
+      <arcpath arcPointType="false" id="0" xCoord="650" yCoord="266"/>
+      <arcpath arcPointType="false" id="1" xCoord="871" yCoord="185"/>
     </arc>
     <arc id="A11" inscription="1" nameOffsetX="0" nameOffsetY="0" source="fire_jointly" target="charging" type="normal" weight="1">
       <hlinscription>
@@ -286,7 +286,7 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="639" yCoord="270"/>
+      <arcpath arcPointType="false" id="0" xCoord="640" yCoord="271"/>
       <arcpath arcPointType="false" id="1" xCoord="405" yCoord="270"/>
       <arcpath arcPointType="false" id="2" xCoord="405" yCoord="195"/>
     </arc>
@@ -307,7 +307,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="870" yCoord="180"/>
-      <arcpath arcPointType="false" id="1" xCoord="769" yCoord="180"/>
+      <arcpath arcPointType="false" id="1" xCoord="770" yCoord="180"/>
     </arc>
     <arc id="I12" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="charged" target="all_fired" type="tapnInhibitor" weight="1">
       <hlinscription>
@@ -328,7 +328,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="660" yCoord="180"/>
-      <arcpath arcPointType="false" id="1" xCoord="759" yCoord="180"/>
+      <arcpath arcPointType="false" id="1" xCoord="760" yCoord="181"/>
     </arc>
     <arc id="I13" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="firing" target="fire_alone" type="tapnInhibitor" weight="1">
       <hlinscription>
@@ -348,9 +348,9 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="883" yCoord="165"/>
+      <arcpath arcPointType="false" id="0" xCoord="884" yCoord="165"/>
       <arcpath arcPointType="true" id="1" xCoord="840" yCoord="75"/>
-      <arcpath arcPointType="false" id="2" xCoord="755" yCoord="70"/>
+      <arcpath arcPointType="false" id="2" xCoord="756" yCoord="70"/>
     </arc>
   </net>
   <query active="true" algorithmOption="CERTAIN_ZERO" capacity="4" gcd="false" name="All fireflies synchronize" numberOfTraces="1" overApproximation="false" parallel="true" reductionOption="VerifyDTAPN" smcTraceType="Any" timeDarts="false" traceOption="NONE" type="SMC" verificationType="Quantitative">

--- a/src/main/resources/Example nets/stochastic-consumer-producer.tapn
+++ b/src/main/resources/Example nets/stochastic-consumer-producer.tapn
@@ -61,11 +61,11 @@
         </structure>
       </type>
     </place>
-    <transition a="0.5" angle="0" b="1.5" displayName="true" distribution="uniform" firingMode="Oldest" id="Recover" infiniteServer="false" name="Recover" nameOffsetX="63" nameOffsetY="-38" player="0" positionX="75" positionY="195" priority="0" urgent="false" weight="1.0"/>
-    <transition angle="0" displayName="true" distribution="normal" firingMode="Oldest" id="Produce" infiniteServer="false" mean="1.5" name="Produce" nameOffsetX="98" nameOffsetY="-31" player="0" positionX="285" positionY="195" priority="0" stddev="0.3" urgent="false" weight="1.0"/>
+    <transition a="0.5" angle="0" b="1.5" displayName="true" distribution="uniform" firingMode="Random" id="Recover" infiniteServer="false" name="Recover" nameOffsetX="63" nameOffsetY="-38" player="0" positionX="75" positionY="195" priority="0" urgent="false" weight="1.0"/>
+    <transition angle="0" displayName="true" distribution="normal" firingMode="Random" id="Produce" infiniteServer="false" mean="1.5" name="Produce" nameOffsetX="98" nameOffsetY="-31" player="0" positionX="285" positionY="195" priority="0" stddev="0.3" urgent="false" weight="1.0"/>
     <transition angle="0" displayName="true" distribution="exponential" firingMode="Random" id="Consume1" infiniteServer="false" name="Consume1" nameOffsetX="124" nameOffsetY="7" player="0" positionX="615" positionY="120" priority="0" rate="0.4" urgent="false" weight="1.0"/>
     <transition angle="0" displayName="true" distribution="exponential" firingMode="Youngest" id="Consume2" infiniteServer="false" name="Consume2" nameOffsetX="125" nameOffsetY="9" player="0" positionX="615" positionY="270" priority="0" rate="0.6" urgent="false" weight="1.0"/>
-    <transition angle="0" displayName="true" distribution="constant" firingMode="Oldest" id="Expire" infiniteServer="false" name="Expire" nameOffsetX="107" nameOffsetY="-1" player="0" positionX="435" positionY="300" priority="0" urgent="false" value="0.0" weight="Infinity"/>
+    <transition angle="0" displayName="true" distribution="constant" firingMode="Random" id="Expire" infiniteServer="false" name="Expire" nameOffsetX="107" nameOffsetY="-1" player="0" positionX="435" positionY="300" priority="0" urgent="false" value="0.0" weight="inf"/>
     <arc id="A0" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="Ready" target="Produce" type="timed" weight="1">
       <hlinscription>
         <text>1'dot</text>
@@ -82,8 +82,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="207" yCoord="143"/>
-      <arcpath arcPointType="false" id="1" xCoord="296" yCoord="206"/>
+      <arcpath arcPointType="false" id="0" xCoord="207" yCoord="144"/>
+      <arcpath arcPointType="false" id="1" xCoord="295" yCoord="206"/>
     </arc>
     <arc id="A1" inscription="1" nameOffsetX="0" nameOffsetY="0" source="Produce" target="Resting" type="normal" weight="1">
       <hlinscription>
@@ -102,7 +102,7 @@
         </structure>
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="295" yCoord="216"/>
-      <arcpath arcPointType="false" id="1" xCoord="207" yCoord="277"/>
+      <arcpath arcPointType="false" id="1" xCoord="207" yCoord="276"/>
     </arc>
     <arc id="A2" inscription="[0,inf)" nameOffsetX="0" nameOffsetY="0" source="Resting" target="Recover" type="timed" weight="1">
       <hlinscription>
@@ -120,8 +120,8 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="183" yCoord="277"/>
-      <arcpath arcPointType="false" id="1" xCoord="95" yCoord="216"/>
+      <arcpath arcPointType="false" id="0" xCoord="183" yCoord="276"/>
+      <arcpath arcPointType="false" id="1" xCoord="95" yCoord="215"/>
     </arc>
     <arc id="A3" inscription="1" nameOffsetX="0" nameOffsetY="0" source="Recover" target="Ready" type="normal" weight="1">
       <hlinscription>
@@ -139,7 +139,7 @@
           </numberof>
         </structure>
       </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="96" yCoord="206"/>
+      <arcpath arcPointType="false" id="0" xCoord="95" yCoord="205"/>
       <arcpath arcPointType="false" id="1" xCoord="183" yCoord="144"/>
     </arc>
     <arc id="A4" inscription="1" nameOffsetX="0" nameOffsetY="0" source="Produce" target="Store" type="normal" weight="1">
@@ -199,25 +199,6 @@
       <arcpath arcPointType="false" id="0" xCoord="464" yCoord="216"/>
       <arcpath arcPointType="false" id="1" xCoord="625" yCoord="286"/>
     </arc>
-    <arc id="A7" inscription="[9,inf):1" nameOffsetX="0" nameOffsetY="0" source="Expire" target="Waste" transportID="1" type="transport" weight="1">
-      <hlinscription>
-        <text>1'dot</text>
-        <structure>
-          <numberof>
-            <subterm>
-              <numberconstant value="1">
-                <positive/>
-              </numberconstant>
-            </subterm>
-            <subterm>
-              <useroperator declaration="dot"/>
-            </subterm>
-          </numberof>
-        </structure>
-      </hlinscription>
-      <arcpath arcPointType="false" id="0" xCoord="450" yCoord="330"/>
-      <arcpath arcPointType="false" id="1" xCoord="450" yCoord="405"/>
-    </arc>
     <arc id="A9" inscription="[9,inf):1" nameOffsetX="0" nameOffsetY="0" source="Store" target="Expire" transportID="1" type="transport" weight="1">
       <hlinscription>
         <text>1'dot</text>
@@ -236,6 +217,25 @@
       </hlinscription>
       <arcpath arcPointType="false" id="0" xCoord="450" yCoord="225"/>
       <arcpath arcPointType="false" id="1" xCoord="450" yCoord="300"/>
+    </arc>
+    <arc id="A7" inscription="[9,inf):1" nameOffsetX="0" nameOffsetY="0" source="Expire" target="Waste" transportID="1" type="transport" weight="1">
+      <hlinscription>
+        <text>1'dot</text>
+        <structure>
+          <numberof>
+            <subterm>
+              <numberconstant value="1">
+                <positive/>
+              </numberconstant>
+            </subterm>
+            <subterm>
+              <useroperator declaration="dot"/>
+            </subterm>
+          </numberof>
+        </structure>
+      </hlinscription>
+      <arcpath arcPointType="false" id="0" xCoord="450" yCoord="330"/>
+      <arcpath arcPointType="false" id="1" xCoord="450" yCoord="405"/>
     </arc>
   </net>
   <query active="true" algorithmOption="CERTAIN_ZERO" capacity="4" gcd="false" name="Stays under capacity" numberOfTraces="1" overApproximation="false" parallel="true" reductionOption="VerifyDTAPN" smcTraceType="Any" timeDarts="false" traceOption="NONE" type="SMC" verificationType="Quantitative">


### PR DESCRIPTION
Fixed some small bugs regarding stochastic transitions : 
- Urgent prevent editing weight/firing mode
- Color guards prevent displaying stochastic informations
- Unified infinite weight exporting/parsing to "inf" regarding https://bugs.launchpad.net/tapaal/+bug/2081687 
- Changed firing mode of examples to "Random" so it is not displayed in the canvas