### PR TITLE
SMC step bound in simulate is wrong - fix 2084485

### DIFF
--- a/src/main/java/dk/aau/cs/verification/SMCSettings.java
+++ b/src/main/java/dk/aau/cs/verification/SMCSettings.java
@@ -40,4 +40,20 @@ public class SMCSettings {
             Math.log(2.0 / (1 - confidence)) / (2.0 * runsNeeded)
         );
     }
+
+    public void setTimeBound(int timeBound) {
+        this.timeBound = timeBound;
+    }
+
+    public void setStepBound(int stepBound) {
+        this.stepBound = stepBound;
+    }
+
+    public int getTimeBound() {
+        return timeBound;
+    }
+
+    public int getStepBound() {
+        return stepBound;
+    }
 }

--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -585,7 +585,12 @@ public class QueryDialog extends JPanel {
             query.setParallel(smcParallel.isSelected());
             VerificationType verificationType = VerificationType.fromOrdinal(smcVerificationType.getSelectedIndex());
             if (verificationType == VerificationType.SIMULATE) {
-                query.setSmcSettings(SMCSettings.Default());
+                SMCSettings newSettings = SMCSettings.Default();
+                SMCSettings oldSettings = getSMCSettings();
+                newSettings.setStepBound(oldSettings.getStepBound());
+                newSettings.setTimeBound(oldSettings.getTimeBound());
+                
+                query.setSmcSettings(newSettings);
             } else {
                 query.setSmcSettings(getSMCSettings());
             }


### PR DESCRIPTION
Fixes:
https://bugs.launchpad.net/tapaal/+bug/2084485

Previously it was using the default settings for timebound and stepbound when using simulate