### PR TITLE
Updated searchbar behavior and macOS textfield fixes

### DIFF
--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -6071,6 +6071,8 @@ public class QueryDialog extends JPanel {
                 refreshUndoRedo();
                 updateSelection(original);
                 queryChanged();
+            } else {
+                undoManager.undo();
             }
         }
 

--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -1351,7 +1351,6 @@ public class QueryDialog extends JPanel {
 				replacement = new TCTLPathPlaceHolder();
 			}
 			if (replacement != null) {
-				UndoableEdit edit = new QueryConstructionEdit(selection, replacement);
 				newProperty = newProperty.replace(selection, replacement);
             } else if (selection instanceof TCTLAbstractPathProperty) {
                 replacement = new TCTLPathPlaceHolder();
@@ -1363,7 +1362,6 @@ public class QueryDialog extends JPanel {
                 }
 
                 UndoableEdit edit = new QueryConstructionEdit(selection, replacement);
-                newProperty = newProperty.replace(selection,	replacement);
 
                 if (selection instanceof TCTLAbstractPathProperty)
                     resetQuantifierSelectionButtons();
@@ -1383,8 +1381,7 @@ public class QueryDialog extends JPanel {
 
     private void setSaveButtonsEnabled() {
         if (!queryField.isEditable()) {
-            boolean isQueryOk = getQueryComment().length() > 0
-                && !newProperty.containsPlaceHolder();
+            boolean isQueryOk = getQueryComment().length() > 0 && !newProperty.containsPlaceHolder();
             saveButton.setEnabled(isQueryOk);
             saveAndVerifyButton.setEnabled(isQueryOk);
             saveUppaalXMLButton.setEnabled(isQueryOk);
@@ -6063,6 +6060,20 @@ public class QueryDialog extends JPanel {
 
     private void cancelAndExit() {
         cancelTraceChanges();
+    
+        // Ensure all query edits are undone
+        while (undoManager.canUndo()) {
+            UndoableEdit edit = undoManager.GetNextEditToUndo();
+            if (edit instanceof QueryConstructionEdit) {
+                TCTLAbstractProperty original = ((QueryConstructionEdit) edit)
+                        .getOriginal();
+                undoManager.undo();
+                refreshUndoRedo();
+                updateSelection(original);
+                queryChanged();
+            }
+        }
+
         exit();
     }
 
@@ -6445,7 +6456,8 @@ public class QueryDialog extends JPanel {
                 smcTimeEstimationButton.setText(UPDATE_VERIFICATION_TIME_BTN_TEXT);
                 try {
                     Float.parseFloat(smcEstimationIntervalWidth.getText());
-                    smcTimeEstimationButton.setEnabled(true);
+                    boolean isQueryOk = getQueryComment().length() > 0 && !newProperty.containsPlaceHolder();
+                    smcTimeEstimationButton.setEnabled(!queryField.isEditable() && isQueryOk);
                 } catch(NumberFormatException e) {
                     smcTimeEstimationButton.setEnabled(false);
                 }
@@ -6473,7 +6485,8 @@ public class QueryDialog extends JPanel {
                 smcTimeEstimationButton.setText(UPDATE_PRECISION_BTN_TEXT);
                 try {
                     Double.parseDouble(smcTimeExpected.getText());
-                    smcTimeEstimationButton.setEnabled(true);
+                    boolean isQueryOk = getQueryComment().length() > 0 && !newProperty.containsPlaceHolder();
+                    smcTimeEstimationButton.setEnabled(!queryField.isEditable() && isQueryOk);
                 } catch(NumberFormatException e) {
                     smcTimeEstimationButton.setEnabled(false);
                 }

--- a/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
+++ b/src/main/java/net/tapaal/gui/petrinet/dialog/QueryDialog.java
@@ -91,6 +91,7 @@ import javax.swing.undo.UndoableEdit;
 import javax.swing.undo.UndoableEditSupport;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
+import java.awt.event.FocusAdapter;
 
 import dk.aau.cs.TCTL.HyperLTLPathScopeNode;
 import dk.aau.cs.TCTL.LTLANode;
@@ -216,8 +217,6 @@ public class QueryDialog extends JPanel {
     public static final String UPDATE_PRECISION_BTN_TEXT = "Compute precision for the given verification time";
 
 	private static final String UPPAAL_SOME_TRACE_STRING = "Some trace       ";
-	private static final String SOME_TRACE_STRING = "Some trace       ";
-	private static final String FASTEST_TRACE_STRING = "Fastest trace       ";
 	private static final String SHARED = "Shared";
 
     public enum QueryDialogueOption {
@@ -1391,12 +1390,14 @@ public class QueryDialog extends JPanel {
             saveUppaalXMLButton.setEnabled(isQueryOk);
             mergeNetComponentsButton.setEnabled(isQueryOk);
             openReducedNetButton.setEnabled(isQueryOk && useReduction.isSelected());
+            smcTimeEstimationButton.setEnabled(isQueryOk);
         } else {
             saveButton.setEnabled(false);
             saveAndVerifyButton.setEnabled(false);
             saveUppaalXMLButton.setEnabled(false);
             mergeNetComponentsButton.setEnabled(false);
             openReducedNetButton.setEnabled(false);
+            smcTimeEstimationButton.setEnabled(false);
         }
     }
 
@@ -2991,6 +2992,13 @@ public class QueryDialog extends JPanel {
         subPanelGbc.fill = GridBagConstraints.HORIZONTAL;
         smcTimeBoundValue = new JTextField(7);
         DocumentFilters.applyIntegerFilter(smcTimeBoundValue);
+        smcTimeBoundValue.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent evt) {
+                int endIdx = smcTimeBoundValue.getText().length();
+                smcTimeBoundValue.setSelectionStart(endIdx);
+                smcTimeBoundValue.setSelectionEnd(endIdx);
+            }
+        });
         smcTimeBoundValue.setToolTipText(TOOL_TIP_TIME_BOUND);
         smcEngineOptions.add(smcTimeBoundValue, subPanelGbc);
         smcTimeBoundValue.addFocusListener(updater);
@@ -3008,6 +3016,13 @@ public class QueryDialog extends JPanel {
         subPanelGbc.gridx = 1;
         subPanelGbc.fill = GridBagConstraints.HORIZONTAL;
         smcStepBoundValue = new JTextField(7);
+        smcStepBoundValue.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent evt) {
+                int endIdx = smcStepBoundValue.getText().length();
+                smcStepBoundValue.setSelectionStart(endIdx);
+                smcStepBoundValue.setSelectionEnd(endIdx);
+            }
+        });
         DocumentFilters.applyIntegerFilter(smcStepBoundValue);
         smcStepBoundValue.setToolTipText(TOOL_TIP_STEP_BOUND);
         smcEngineOptions.add(smcStepBoundValue, subPanelGbc);
@@ -3041,6 +3056,13 @@ public class QueryDialog extends JPanel {
         quantitativePanel.add(new JLabel("Confidence : "), subPanelGbc);
         subPanelGbc.gridx = 1;
         smcConfidence = new JTextField(7);
+        smcConfidence.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent evt) {
+                int endIdx = smcConfidence.getText().length();
+                smcConfidence.setSelectionStart(endIdx);
+                smcConfidence.setSelectionEnd(endIdx);
+            }
+        });
         DocumentFilters.applyDoubleFilter(smcConfidence);
         smcConfidence.addFocusListener(updater);
         smcConfidence.setToolTipText(TOOL_TIP_CONFIDENCE);
@@ -3067,6 +3089,13 @@ public class QueryDialog extends JPanel {
         quantitativePanel.add(new JLabel("Precision : "), subPanelGbc);
         subPanelGbc.gridx = 1;
         smcEstimationIntervalWidth = new JTextField(7);
+        smcEstimationIntervalWidth.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent evt) {
+                int endIdx = smcEstimationIntervalWidth.getText().length();
+                smcEstimationIntervalWidth.setSelectionStart(endIdx);
+                smcEstimationIntervalWidth.setSelectionEnd(endIdx);
+            }
+        });
         DocumentFilters.applyDoubleFilter(smcEstimationIntervalWidth);
         smcEstimationIntervalWidth.addFocusListener(updater);
         smcEstimationIntervalWidth.setToolTipText(TOOL_TIP_INTERVAL_WIDTH);
@@ -3100,6 +3129,13 @@ public class QueryDialog extends JPanel {
         quantitativePanel.add(verifTimeLabel, subPanelGbc);
         subPanelGbc.gridx = 1;
         smcTimeExpected = new JTextField(7);
+        smcTimeExpected.addFocusListener(new FocusAdapter() {
+            public void focusGained(FocusEvent evt) {
+                int endIdx = smcTimeExpected.getText().length();
+                smcTimeExpected.setSelectionStart(endIdx);
+                smcTimeExpected.setSelectionEnd(endIdx);
+            }
+        });
         DocumentFilters.applyDoubleFilter(smcTimeExpected);
         smcTimeExpected.setToolTipText(TOOL_TIP_VERIFICATION_TIME);
         quantitativePanel.add(smcTimeExpected, subPanelGbc);

--- a/src/main/java/pipe/gui/GuiFrame.java
+++ b/src/main/java/pipe/gui/GuiFrame.java
@@ -1010,6 +1010,8 @@ public class GuiFrame extends JFrame implements GuiFrameActions, SafeGuiFrameAct
 
             selectedObject.select();
             drawingSurface.scrollToCenter(selectedObject);
+
+            enableActionsForSearchBar(true);
         });
         
 

--- a/src/main/java/pipe/gui/GuiFrame.java
+++ b/src/main/java/pipe/gui/GuiFrame.java
@@ -875,9 +875,17 @@ public class GuiFrame extends JFrame implements GuiFrameActions, SafeGuiFrameAct
 
         JMenuItem clearPreferences = new JMenuItem(clearPreferencesAction);
         toolsMenu.add(clearPreferences);
-
         return toolsMenu;
     }
+
+    private final AbstractAction searchAction = new AbstractAction() {
+        @Override
+        public void actionPerformed(ActionEvent e) {
+            if (searchBar != null && searchBar.isEnabled()) {
+                searchBar.requestFocusInWindow();
+            }
+        }
+    };
 
     private void buildToolbar() {
 
@@ -937,6 +945,12 @@ public class GuiFrame extends JFrame implements GuiFrameActions, SafeGuiFrameAct
         searchToolBar.setRequestFocusEnabled(false);
 
         searchBar = new SearchBar();   
+        JRootPane rootPane = getRootPane();
+        InputMap inputMap = rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
+        ActionMap actionMap = rootPane.getActionMap();
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F, shortcutkey | InputEvent.ALT_DOWN_MASK), "focusSearchBar");
+        actionMap.put("focusSearchBar", searchAction);
+
         searchBar.setOnFocusGained(() -> {
             currentTab.ifPresent(o -> o.setMode(PetriNetTab.DrawTool.SELECT));
             enableActionsForSearchBar(false);
@@ -1010,9 +1024,6 @@ public class GuiFrame extends JFrame implements GuiFrameActions, SafeGuiFrameAct
 
             selectedObject.select();
             drawingSurface.scrollToCenter(selectedObject);
-
-            searchBar.setFocusable(false);
-            searchBar.setFocusable(true);
         });
         
 

--- a/src/main/java/pipe/gui/GuiFrame.java
+++ b/src/main/java/pipe/gui/GuiFrame.java
@@ -254,7 +254,7 @@ public class GuiFrame extends JFrame implements GuiFrameActions, SafeGuiFrameAct
             currentTab.ifPresent(TabActions::verifySelectedQuery);
         }
     };
-    private final GuiAction workflowDialogAction = new GuiAction("Workflow analysis", "Analyse net as a TAWFN", KeyStroke.getKeyStroke(KeyEvent.VK_F, shortcutkey)) {
+    private final GuiAction workflowDialogAction = new GuiAction("Workflow analysis", "Analyse net as a TAWFN", KeyStroke.getKeyStroke(KeyEvent.VK_W, shortcutkey | InputEvent.SHIFT_DOWN_MASK)) {
         public void actionPerformed(ActionEvent e) {
             currentTab.ifPresent(TabActions::workflowAnalyse);
         }
@@ -948,7 +948,7 @@ public class GuiFrame extends JFrame implements GuiFrameActions, SafeGuiFrameAct
         JRootPane rootPane = getRootPane();
         InputMap inputMap = rootPane.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW);
         ActionMap actionMap = rootPane.getActionMap();
-        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F, shortcutkey | InputEvent.ALT_DOWN_MASK), "focusSearchBar");
+        inputMap.put(KeyStroke.getKeyStroke(KeyEvent.VK_F, shortcutkey), "focusSearchBar");
         actionMap.put("focusSearchBar", searchAction);
 
         searchBar.setOnFocusGained(() -> {

--- a/src/main/java/pipe/gui/GuiFrame.java
+++ b/src/main/java/pipe/gui/GuiFrame.java
@@ -1011,7 +1011,8 @@ public class GuiFrame extends JFrame implements GuiFrameActions, SafeGuiFrameAct
             selectedObject.select();
             drawingSurface.scrollToCenter(selectedObject);
 
-            enableActionsForSearchBar(true);
+            searchBar.setFocusable(false);
+            searchBar.setFocusable(true);
         });
         
 

--- a/src/main/java/pipe/gui/GuiFrame.java
+++ b/src/main/java/pipe/gui/GuiFrame.java
@@ -940,6 +940,11 @@ public class GuiFrame extends JFrame implements GuiFrameActions, SafeGuiFrameAct
         searchBar.setOnFocusGained(() -> {
             currentTab.ifPresent(o -> o.setMode(PetriNetTab.DrawTool.SELECT));
             enableActionsForSearchBar(false);
+
+            if (!searchBar.getSearchText().isEmpty()) {
+                String query = searchBar.getSearchText();
+                currentTab.ifPresent(o -> o.search(query));
+            }
         });    
 
         searchBar.setOnFocusLost(() -> {

--- a/src/main/java/pipe/gui/petrinet/SearchBar.java
+++ b/src/main/java/pipe/gui/petrinet/SearchBar.java
@@ -102,11 +102,8 @@ public class SearchBar extends JPanel {
             }
             
             public void focusLost(FocusEvent evt) {
-                if (!evt.isTemporary() && !resultsPopup.isVisible()) {
-                    resultsPopup.setVisible(false);
-                }
-                
                 if (!evt.isTemporary() && onFocusLost != null) {
+                    resultsPopup.setVisible(false);
                     onFocusLost.run();
                 }
             }

--- a/src/main/java/pipe/gui/petrinet/SearchBar.java
+++ b/src/main/java/pipe/gui/petrinet/SearchBar.java
@@ -257,4 +257,10 @@ public class SearchBar extends JPanel {
     public void clear() {
         searchField.setText("");
     }
+
+    @Override
+    public void setFocusable(boolean focusable) {
+        super.setFocusable(focusable);
+        searchField.setFocusable(focusable);
+    }
 }

--- a/src/main/java/pipe/gui/petrinet/SearchBar.java
+++ b/src/main/java/pipe/gui/petrinet/SearchBar.java
@@ -259,8 +259,7 @@ public class SearchBar extends JPanel {
     }
 
     @Override
-    public void setFocusable(boolean focusable) {
-        super.setFocusable(focusable);
-        searchField.setFocusable(focusable);
+    public boolean requestFocusInWindow() {
+        return searchField.requestFocusInWindow();
     }
 }

--- a/src/main/java/pipe/gui/petrinet/graphicElements/PetriNetObject.java
+++ b/src/main/java/pipe/gui/petrinet/graphicElements/PetriNetObject.java
@@ -53,6 +53,12 @@ public abstract class PetriNetObject extends GraphicalElement implements Drawabl
         setOriginalX(positionXInput);
         setOriginalY(positionYInput);
 
+        addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                requestFocusInWindow();
+            }
+        });
 	}
 
     public JPopupMenu getPopup(MouseEvent e) {


### PR DESCRIPTION
+ Searchbar now opens results when gaining focus and text not empty
+ macOS selecting all in some textfields fix
+ Compute estimated verification time now disabled when invalid query