### PR TITLE
Fixed missing space between windows options and model file

### DIFF
--- a/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPN.java
+++ b/src/main/java/dk/aau/cs/verification/VerifyTAPN/VerifyPN.java
@@ -494,7 +494,7 @@ public class VerifyPN implements ModelChecker {
 
     private String createArgumentString(String modelFile, String queryFile, String options) {
         if (Platform.isWindows()) {
-            return options + "\"" + modelFile + "\" \"" + queryFile + "\"";
+            return options + " \"" + modelFile + "\" \"" + queryFile + "\"";
         }
 
         return options + ' ' + modelFile + ' ' + queryFile;


### PR DESCRIPTION
Fixed missing space between windows options and model file which caused some of the example models e.g. ERK to fail when verifying