### PR TITLE
Component ambiguity fix

### DIFF
--- a/src/main/java/dk/aau/cs/TCTL/TCTLPlaceNode.java
+++ b/src/main/java/dk/aau/cs/TCTL/TCTLPlaceNode.java
@@ -30,10 +30,10 @@ public class TCTLPlaceNode extends TCTLAbstractStateProperty {
 
     @Override
     public void convertForReducedNet(String templateName) {
-	    if(template.isEmpty()){
-            place = "Shared_" + place;
+	    if (template.isEmpty()) {
+            place = "Shared__" + place;
         } else {
-            place = template + "_" + place;
+            place = template + "__" + place;
         }
         template = templateName;
     }

--- a/src/main/java/dk/aau/cs/io/queries/TAPNQueryLoader.java
+++ b/src/main/java/dk/aau/cs/io/queries/TAPNQueryLoader.java
@@ -262,30 +262,46 @@ public class TAPNQueryLoader extends QueryLoader{
         String name = element.getTextContent();
         String templateName = null;
         String placeName = null;
+
+        // Order important. Try to split on "__" before using legacy separator "_"
+        String[] separators = {"__", "_"};
         
         final String SHARED = "Shared";
-        if (name.startsWith(SHARED + "_")) {
-            templateName = "Shared";
-            placeName = name.substring((SHARED + "_").length());
-        } else {
+        for (String sep : separators) {
+            if (name.startsWith(SHARED + sep)) {
+                templateName = SHARED;
+                placeName = name.substring((SHARED + sep).length());
+                break;
+            }
+        }
+        
+        if (templateName == null) {
             for (TimedArcPetriNet tapn : network.activeTemplates()) {
-                if (name.startsWith(tapn.name() + "_")) {
-                    String potentialPlaceName = name.substring(tapn.name().length() + 1);
-                    if (tapn.getPlaceByName(potentialPlaceName) != null) {
-                        templateName = tapn.name();
-                        placeName = potentialPlaceName;
-                        break;
+                for (String sep : separators) {
+                    if (name.startsWith(tapn.name() + sep)) {
+                        String potentialPlaceName = name.substring((tapn.name() + sep).length());
+                        if (tapn.getPlaceByName(potentialPlaceName) != null) {
+                            templateName = tapn.name();
+                            placeName = potentialPlaceName;
+                            break;
+                        }
                     }
                 }
+
+                if (templateName != null) break;
             }
         }
 
         if (templateName == null) {
-            String[] parts = name.split("_", 2);
-            if (parts.length == 2) {
-                templateName = parts[0];
-                placeName = parts[1];
-            } else {
+            for (String sep : separators) {
+                String[] parts = name.split(sep, 2);
+                if (parts.length == 2) {
+                    templateName = parts[0];
+                    placeName = parts[1];
+                    break;
+                }
+            }
+            if (templateName == null) {
                 templateName = "";
                 placeName = name;
             }

--- a/src/main/java/dk/aau/cs/verification/TAPNComposer.java
+++ b/src/main/java/dk/aau/cs/verification/TAPNComposer.java
@@ -284,11 +284,11 @@ public class TAPNComposer implements ITAPNComposer {
                         String uniqueTransitionName = "";
                         if (!singleComponentNoPrefix || model.activeTemplates().size() > 1) {
                             uniqueTransitionName = timedTransition.isShared()
-                                ? "Shared_" + timedTransition.name()
-                                : timedTransition.model().name() + "_" + timedTransition.name();
+                                ? "Shared__" + timedTransition.name()
+                                : timedTransition.model().name() + "__" + timedTransition.name();
                         } else {
                             uniqueTransitionName = timedTransition.isShared()
-                                ? "Shared_" + timedTransition.name()
+                                ? "Shared__" + timedTransition.name()
                                 : timedTransition.name();
                         }
 
@@ -647,21 +647,21 @@ public class TAPNComposer implements ITAPNComposer {
 
     public String composedTransitionName(TimedTransition transition) {
         if (transition.isShared()) {
-            return "Shared_" + transition.name();
+            return "Shared__" + transition.name();
         } else if (singleComponentNoPrefix) {
             return transition.name();
         } else {
-            return transition.model().name() + "_" + transition.name();
+            return transition.model().name() + "__" + transition.name();
         }
     }
    
     public String composedPlaceName(TimedPlace place) {
         if (place.isShared()) {
-            return "Shared_" + place.name();
+            return "Shared__" + place.name();
         } else if (singleComponentNoPrefix) {
             return place.name();
         } else {
-            return ((LocalTimedPlace)place).model().name() + "_" + place.name();
+            return ((LocalTimedPlace)place).model().name() + "__" + place.name();
         }
     }
 

--- a/src/main/java/dk/aau/cs/verification/observations/expressions/ObsPlace.java
+++ b/src/main/java/dk/aau/cs/verification/observations/expressions/ObsPlace.java
@@ -51,7 +51,7 @@ public class ObsPlace extends ObsLeaf {
 
     @Override
     public String toXml() {
-        return "<place>" + template + "_" + place.name() + "</place>";
+        return "<place>" + template + "__" + place.name() + "</place>";
     }
 
     @Override

--- a/src/main/java/net/tapaal/gui/petrinet/editor/SharedPlaceNamePanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/SharedPlaceNamePanel.java
@@ -137,12 +137,23 @@ public class SharedPlaceNamePanel extends JPanel {
 			private boolean updateExistingPlace(String name) {
 				String oldName = placeToEdit.name();
 				
-				if(placeToEdit.network().isNameUsed(name) && !oldName.equals(name)) {
-					JOptionPane.showMessageDialog(SharedPlaceNamePanel.this, "The specified name is already used by a place or transition in one of the components.", "Error", JOptionPane.ERROR_MESSAGE);
-					nameField.requestFocusInWindow();
-					return false;
+				if (name.contains("__")) {
+					int result = JOptionPane.showConfirmDialog(SharedPlaceNamePanel.this,
+							"Using double underscores (__) in names is not recommended as it can cause ambiguity issues when using multiple components.\nDo you want to continue?",
+							"Warning",
+							JOptionPane.OK_CANCEL_OPTION,
+							JOptionPane.WARNING_MESSAGE);
+                            
+					if (result != JOptionPane.OK_OPTION) {
+						return false;
+					}
 				}
-				
+
+                if (placeToEdit.network().isNameUsed(name) && !oldName.equals(name)) {
+                    JOptionPane.showMessageDialog(SharedPlaceNamePanel.this, "The specified name is already used by a place or transition in one of the components.", "Error", JOptionPane.ERROR_MESSAGE);
+                    nameField.requestFocusInWindow();
+                    return false;
+                }
 				
 				try{
 					placeToEdit.setName(name);
@@ -163,13 +174,23 @@ public class SharedPlaceNamePanel extends JPanel {
 
 			private boolean addNewSharedPlace(String name) {
 				SharedPlace place = null;
-				try{
-					place = new SharedPlace(name);
-				}catch(RequireException e){
-					JOptionPane.showMessageDialog(SharedPlaceNamePanel.this, "The specified name is invalid.\nAcceptable names are defined by the regular expression:\n[a-zA-Z][_a-zA-Z0-9]* \n\nNote that \"true\" and \"false\" are reserved keywords.", "Error", JOptionPane.ERROR_MESSAGE);
-					nameField.requestFocusInWindow();
-					return false;
-				}
+				   if (name.contains("__")) {
+					   int result = JOptionPane.showConfirmDialog(SharedPlaceNamePanel.this,
+							   "Using double underscores (__) in names is not recommended as it can cause ambiguity issues when using multiple components.\nDo you want to continue?",
+							   "Warning",
+							   JOptionPane.OK_CANCEL_OPTION,
+							   JOptionPane.WARNING_MESSAGE);
+					   if (result != JOptionPane.OK_OPTION) {
+						   return false;
+					   }
+				   }
+				   try{
+					   place = new SharedPlace(name);
+				   }catch(RequireException e){
+					   JOptionPane.showMessageDialog(SharedPlaceNamePanel.this, "The specified name is invalid.\nAcceptable names are defined by the regular expression:\n[a-zA-Z][_a-zA-Z0-9]* \n\nNote that \"true\" and \"false\" are reserved keywords.", "Error", JOptionPane.ERROR_MESSAGE);
+					   nameField.requestFocusInWindow();
+					   return false;
+				   }
 				
 				try{
 					listModel.addElement(place);

--- a/src/main/java/net/tapaal/gui/petrinet/editor/SharedTransitionNamePanel.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/SharedTransitionNamePanel.java
@@ -140,13 +140,25 @@ public class SharedTransitionNamePanel extends JPanel {
 				
 				String oldName = transitionToEdit.name();
 				
-				if(transitionToEdit.network().isNameUsed(name) && !oldName.equals(name)) {
-					JOptionPane.showMessageDialog(SharedTransitionNamePanel.this, "The specified name is already used by a place or transition in one of the components.", "Error", JOptionPane.ERROR_MESSAGE);
-					nameField.requestFocusInWindow();
-					return false;
+				if (name.contains("__")) {
+					int result = JOptionPane.showConfirmDialog(SharedTransitionNamePanel.this,
+							"Using double underscores (__) in names is not recommended as it can cause ambiguity issues when using multiple components.\nDo you want to continue?",
+							"Warning",
+							JOptionPane.OK_CANCEL_OPTION,
+							JOptionPane.WARNING_MESSAGE);
+                            
+					if (result != JOptionPane.OK_OPTION) {
+						return false;
+					}
 				}
+
+                if (transitionToEdit.network().isNameUsed(name) && !oldName.equals(name)) {
+                    JOptionPane.showMessageDialog(SharedTransitionNamePanel.this, "The specified name is already used by a place or transition in one of the components.", "Error", JOptionPane.ERROR_MESSAGE);
+                    nameField.requestFocusInWindow();
+                    return false;
+                }
 				
-				
+			
 				try{
 					transitionToEdit.setName(name);
 				}catch(RequireException e){
@@ -166,13 +178,24 @@ public class SharedTransitionNamePanel extends JPanel {
 			private boolean addNewSharedTransition(String name) {
 				SharedTransition transition = null;
 				
-				try{
-					transition = new SharedTransition(name);
-				}catch(RequireException e){
-					JOptionPane.showMessageDialog(SharedTransitionNamePanel.this, "The specified name is invalid.\nAcceptable names are defined by the regular expression:\n[a-zA-Z][_a-zA-Z0-9]*", "Error", JOptionPane.ERROR_MESSAGE);
-					nameField.requestFocusInWindow();
-					return false;
+				if (name.contains("__")) {
+					int result = JOptionPane.showConfirmDialog(SharedTransitionNamePanel.this,
+							"Using double underscores (__) in names is not recommended as it can cause ambiguity issues when using multiple components.\nDo you want to continue?",
+							"Warning",
+							JOptionPane.OK_CANCEL_OPTION,
+							JOptionPane.WARNING_MESSAGE);
+					if (result != JOptionPane.OK_OPTION) {
+						return false;
+					}
 				}
+
+                try {
+                    transition = new SharedTransition(name);
+                } catch(RequireException e){
+                    JOptionPane.showMessageDialog(SharedTransitionNamePanel.this, "The specified name is invalid.\nAcceptable names are defined by the regular expression:\n[a-zA-Z][_a-zA-Z0-9]*", "Error", JOptionPane.ERROR_MESSAGE);
+                    nameField.requestFocusInWindow();
+                    return false;
+                }
 				
 				try{
 					listModel.addElement(transition);

--- a/src/main/java/net/tapaal/gui/petrinet/editor/TemplateExplorer.java
+++ b/src/main/java/net/tapaal/gui/petrinet/editor/TemplateExplorer.java
@@ -432,6 +432,16 @@ public class TemplateExplorer extends JPanel implements SidePane {
 			exit();
 			return;
 		}
+		if (newName.equalsIgnoreCase("Shared")) {
+			JOptionPane.showMessageDialog(
+							parent.drawingSurface(),
+							"The component name 'Shared' is reserved for the global component and cannot be used.\n\nThe component could not be renamed.",
+							"Error Renaming Component",
+							JOptionPane.ERROR_MESSAGE);
+			exit();
+			showRenameTemplateDialog(newName);
+			return;
+		}
 		if (!isNameAllowed(newName)) {
 			JOptionPane.showMessageDialog(
 							parent.drawingSurface(),
@@ -461,6 +471,16 @@ public class TemplateExplorer extends JPanel implements SidePane {
 	
 	private void onOK() {
         String templateName = nameTextField.getText().trim();
+		if (templateName.equalsIgnoreCase("Shared")) {
+			JOptionPane.showMessageDialog(
+							parent.drawingSurface(),
+							"The component name 'Shared' is reserved for the global component and cannot be used.\n\nThe new component could not be created.",
+							"Error Creating Component",
+							JOptionPane.ERROR_MESSAGE);
+			exit();
+			ShowNewTemplateDialog(templateName);
+			return;
+		}
         if(!isNameAllowed(templateName)) {
             JOptionPane.showMessageDialog(parent.drawingSurface(),
                     "Acceptable names for components are defined by the regular expression:\n[a-zA-Z][_a-zA-Z0-9]*\n\nThe new component could not be created.",

--- a/src/main/java/net/tapaal/gui/petrinet/verification/KBoundAnalyzer.java
+++ b/src/main/java/net/tapaal/gui/petrinet/verification/KBoundAnalyzer.java
@@ -128,12 +128,12 @@ public class KBoundAnalyzer {
         ArrayList<TCTLAbstractStateProperty> factors = new ArrayList<>();
 
         tapnNetwork.sharedPlaces().forEach(o -> {
-            if (net.getPlaceByName(o.name()) != null && !net.getPlaceByName(o.name()).name().contains("Shared_")) {
-                net.getPlaceByName(o.name()).setName("Shared_" + o.name());
+            if (net.getPlaceByName(o.name()) != null && !net.getPlaceByName(o.name()).name().contains("Shared__")) {
+                net.getPlaceByName(o.name()).setName("Shared__" + o.name());
             }
         });
         tapnNetwork.allTemplates().forEach(o -> o.places().forEach(x -> {
-            if (net.getPlaceByName(x.name()) != null) net.getPlaceByName(x.name()).setName(o.name() + "_" + x.name());
+            if (net.getPlaceByName(x.name()) != null) net.getPlaceByName(x.name()).setName(o.name() + "__" + x.name());
         }));
 
         for (TimedPlace place : net.places()) {

--- a/src/main/java/pipe/gui/petrinet/editor/PlaceEditorPanel.java
+++ b/src/main/java/pipe/gui/petrinet/editor/PlaceEditorPanel.java
@@ -147,11 +147,23 @@ public class PlaceEditorPanel extends JPanel {
 		okButton.setMinimumSize(new java.awt.Dimension(100, 25));
 		okButton.setPreferredSize(new java.awt.Dimension(100, 25));
 
-		okButton.addActionListener(evt -> {
-			if(doOK()){
-				exit();
-			}
-		});
+        okButton.addActionListener(evt -> {
+            String name = nameTextField.getText();
+            if (name != null && name.contains("__")) {
+                int result = JOptionPane.showConfirmDialog(this,
+                        "Using double underscores (__) in names is not recommended as it can cause ambiguity issues when using multiple components.\nDo you want to continue?",
+                        "Warning",
+                        JOptionPane.OK_CANCEL_OPTION,
+                        JOptionPane.WARNING_MESSAGE);
+                if (result != JOptionPane.OK_OPTION) {
+                    return;
+                }
+            }
+            
+            if (doOK()) {
+                exit();
+            }
+        });
 		rootPane.setDefaultButton(okButton);
 
 		cancelButton = new javax.swing.JButton();

--- a/src/main/java/pipe/gui/petrinet/editor/TAPNTransitionEditor.java
+++ b/src/main/java/pipe/gui/petrinet/editor/TAPNTransitionEditor.java
@@ -291,7 +291,19 @@ public class TAPNTransitionEditor extends JPanel {
 		okButton.setMinimumSize(new java.awt.Dimension(100, 25));
 		okButton.setPreferredSize(new java.awt.Dimension(100, 25));
 		okButton.addActionListener(evt -> {
-			if(okButtonHandler(evt)){
+			String name = nameTextField.getText();
+			if (name != null && name.contains("__")) {
+				int result = JOptionPane.showConfirmDialog(this,
+						"Using double underscores (__) in names is not recommended as it can cause ambiguity issues when using multiple components.\nDo you want to continue?",
+						"Warning",
+						JOptionPane.OK_CANCEL_OPTION,
+						JOptionPane.WARNING_MESSAGE);
+				if (result != JOptionPane.OK_OPTION) {
+					return;
+				}
+			}
+            
+			if (okButtonHandler(evt)) {
 				exit();
 			}
 		});


### PR DESCRIPTION
Fixes problems with ambiguity between components using underscores and places in the UI.

To see the problem:
Create a component "a" with a place "b_P0". Create a component "a_b" with a place "P0". In the XML, they will both look like <place>a_b_P0</place>.

This PR changes the place format for observations and places in queries by separating the component name and place/transition name with double underscores